### PR TITLE
BUG: Contiguous communication buffers

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -217,13 +217,16 @@ jobs:
       # ctest hides a passing test's stdout, so the device test outcomes are not
       # otherwise visible. Re-run the Python tests with -v -rA so the log shows
       # exactly which GPU tests executed (vs. skipped) and their result. Failures
-      # here surface as the device tests actually running.
-      - name: Inspect Python test outcomes on GPU
+      # here surface as the device tests actually running. This run also
+      # measures the Python wrapper layer with pytest-cov: GPU-only wrapper
+      # code (e.g. DeviceMemory.py) can only be covered on this leg.
+      - name: Inspect Python test outcomes on GPU (with coverage)
         run: |
           source venv/bin/activate
           export PYTHONPATH=$PWD/build/language_bindings/python:$PWD/language_bindings/python
           export TESTS_BUILDDIR=$PWD/build/tests
-          python3 -m pytest tests -v -rA -p no:cacheprovider
+          python3 -m pytest tests -v -rA -p no:cacheprovider \
+            --cov=muGrid --cov-report=xml:build/coverage-python.xml
 
       - name: Generate C++ coverage reports
         run: |
@@ -236,6 +239,7 @@ jobs:
           name: coverage-reports-gpu
           path: |
             build/coverage.xml
+            build/coverage-python.xml
             build/coverage_html/
           if-no-files-found: warn
 
@@ -244,6 +248,6 @@ jobs:
         continue-on-error: true
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: build/coverage.xml
+          files: build/coverage.xml,build/coverage-python.xml
           flags: gpu
           fail_ci_if_error: false

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -17,9 +17,11 @@ on:
 # false 0%. The `coverage-gpu` job runs on the GPU-equipped runner with MPI
 # enabled, so the device communication paths (contiguous staging in the
 # transposes and the halo exchange) are exercised by the multi-rank ctest runs
-# sharing the single GPU. All legs upload to Codecov, which merges them. The
-# only remaining gap is CUDA __global__ kernel bodies, which gcov (host-only)
-# cannot instrument.
+# sharing the single GPU. The runner's stock OpenMPI is not GPU-aware; muGrid
+# detects this at runtime and bounces the staging buffers through host memory,
+# so this leg covers exactly the code path users with a plain MPI hit. All
+# legs upload to Codecov, which merges them. The only remaining gap is CUDA
+# __global__ kernel bodies, which gcov (host-only) cannot instrument.
 
 jobs:
   coverage:
@@ -185,7 +187,8 @@ jobs:
 
       # MPI is enabled so the multi-rank ctest runs (which oversubscribe the
       # single GPU) exercise the device communication paths: staged halo
-      # exchange and the staged FFT transposes.
+      # exchange and the staged FFT transposes, via the host-bounce fallback
+      # (stock OpenMPI is not GPU-aware).
       - name: Configure (coverage-instrumented, CUDA + MPI, Debug)
         run: |
           source venv/bin/activate

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -14,10 +14,12 @@ on:
 # wrapper layer (pytest-cov). The `coverage` job runs a serial and an
 # MPI-enabled build on CPU runners so MPI-only code (e.g. fft/transpose.cc, the
 # cartesian communicator/decomposition) is exercised rather than reported as a
-# false 0%. The `coverage-gpu` job runs on the GPU-equipped runner and measures
-# the host-side CUDA dispatch code. All legs upload to Codecov, which merges
-# them. The only remaining gap is CUDA __global__ kernel bodies, which gcov
-# (host-only) cannot instrument.
+# false 0%. The `coverage-gpu` job runs on the GPU-equipped runner with MPI
+# enabled, so the device communication paths (contiguous staging in the
+# transposes and the halo exchange) are exercised by the multi-rank ctest runs
+# sharing the single GPU. All legs upload to Codecov, which merges them. The
+# only remaining gap is CUDA __global__ kernel bodies, which gcov (host-only)
+# cannot instrument.
 
 jobs:
   coverage:
@@ -168,7 +170,9 @@ jobs:
           sudo apt-get install -y \
             cmake \
             ninja-build \
-            libboost-test-dev
+            libboost-test-dev \
+            openmpi-bin \
+            libopenmpi-dev
 
       - name: Install Python dependencies
         run: |
@@ -177,15 +181,19 @@ jobs:
           python3 -m pip install --upgrade pip
           python3 -m pip install numpy pytest pytest-cov gcovr \
             "NuMPI[test]" cupy-cuda12x muTimer
+          CC=mpicc python3 -m pip install -v --no-binary mpi4py "mpi4py==4.0.3"
 
-      - name: Configure (coverage-instrumented, CUDA, Debug)
+      # MPI is enabled so the multi-rank ctest runs (which oversubscribe the
+      # single GPU) exercise the device communication paths: staged halo
+      # exchange and the staged FFT transposes.
+      - name: Configure (coverage-instrumented, CUDA + MPI, Debug)
         run: |
           source venv/bin/activate
           cmake -B build -G Ninja \
             -DCMAKE_BUILD_TYPE=Debug \
             -DMUGRID_ENABLE_COVERAGE=ON \
             -DMUGRID_ENABLE_CUDA=ON \
-            -DMUGRID_ENABLE_MPI=OFF \
+            -DMUGRID_ENABLE_MPI=ON \
             -DMUGRID_ENABLE_NETCDF=OFF \
             -DMUGRID_ENABLE_PYTHON=ON \
             -DMUGRID_ENABLE_TESTS=ON \

--- a/.github/workflows/gpu-tests.yml
+++ b/.github/workflows/gpu-tests.yml
@@ -95,6 +95,8 @@ jobs:
           cd tests
           python3 -m pytest python_field_gpu_tests.py -v -s
           python3 -m pytest python_fem_gradient_gpu_tests.py -v -s
+          # Device-parameterized tests (run their [gpu] variants here)
+          python3 -m pytest python_preconditioner_tests.py -v -s
 
       - name: Run Poisson example (host)
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Change log for µGrid
   instead of strided MPI datatypes; FFT scratch is cached across transforms
 - ENH: Solvers run entirely on the device
 - API: `conjugate_gradients` now converges on a relative criterion
+- BUG: Fixed device `reduce_ghosts` silently dropping all contributions
+  received from MPI neighbors (the host receive buffer was treated as device
+  memory during accumulation); found by a new device-vs-host equivalence test
 - BUG: Interior reductions (`norm_sq`, `vecdot`, `axpy_norm_sq`) on host and
   GPU now sum the interior region directly instead of subtracting the ghost
   contribution from a full-buffer reduction (minimizing floating point overflows)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,45 +1,14 @@
 Change log for µGrid
 ====================
 
-0.107.0 (11Jun26)
+0.107.0 (12Jun26)
 -----------------
 
-- ENH: Device halo exchange and FFT transposes now pack into contiguous
-  device staging buffers instead of handing strided MPI derived datatypes
-  to the MPI library (which packs them block by block on device memory,
-  orders of magnitude slower); multi-GPU stencil and FFT operations now
-  scale. Self-neighbor exchanges (periodic directions that are not
-  subdivided) short-circuit to a local device copy
-- ENH: FFT scratch buffers are cached across transforms instead of being
-  allocated per call; together with the removal of two unused
-  construction-time work fields this reduces device memory pressure and
-  eliminates per-transform cudaMalloc latency
-- ENH: `linalg.scal` accepts a real field as the multiplier, broadcast over
-  components (single-component alpha) or applied elementwise (alpha with
-  matching components), on host and device, for real and complex fields
-- ENH: `FourierPreconditioner` and `JacobiPreconditioner` apply through the
-  fused field kernels and run entirely on the device when the solver fields
-  live there; `JacobiPreconditioner` supports per-component diagonals
-- ENH: `muGrid.use_cupy_allocator()` routes all muGrid device allocations
-  through cupy's memory pool so that one allocator owns the GPU; this
-  prevents out-of-memory failures caused by cupy's pool caching memory that
-  muGrid's raw allocator cannot see (`set_device_allocator` provides the
-  generic hook)
-- ENH: `__dlpack__` honours the consumer's `stream` argument (synchronizes
-  for non-default streams)
-- ENH: New `Solvers.ConvergenceError` (a `RuntimeError` subclass) raised on
-  CG non-convergence, so genuine runtime errors (e.g. out of memory) are
-  distinguishable from non-convergence
-- ENH: All CUDA/HIP portability macros consolidated in a single shim header
-  (`memory/gpu_runtime.hh`); duplicated per-backend GPU wrapper code removed
-- ENH: New microbenchmark `benchmarks/communication_benchmark.py` for halo
-  exchange (per split axis) and FFT/transpose timings
-
-- API: `conjugate_gradients` now converges on a relative criterion by
-  default, ``||b - Ax|| <= max(rtol * ||b||, atol)`` with ``rtol=1e-6``,
-  ``atol=0``; the old absolute `tol` is deprecated (it maps to `atol` with
-  ``rtol=0``). An absolute criterion is unreachable in double precision
-  when ``||b||`` is large and was the cause of erratic CG termination
+- ENH: Multi-GPU halo exchange and FFT transposes now scale: contiguous
+  staging buffers (with a host bounce when MPI is not GPU-aware)
+  instead of strided MPI datatypes; FFT scratch is cached across transforms
+- ENH: Solvers run entirely on the device
+- API: `conjugate_gradients` now converges on a relative criterion
 - BUG: Interior reductions (`norm_sq`, `vecdot`, `axpy_norm_sq`) on host and
   GPU now sum the interior region directly instead of subtracting the ghost
   contribution from a full-buffer reduction (minimizing floating point overflows)
@@ -87,8 +56,9 @@ Change log for µGrid
   silently producing a wrong reduction
 - ENH: The 3D MPI FFT now uses a true pencil decomposition; per-rank memory
   scales as O(N³/P) and Fourier space distributes X across P2, Y across P1
-- ENH: MPI transposes are pure derived-datatype `MPI_Alltoallw` operations
-  (no pack/unpack), running directly on device buffers with a GPU-aware MPI
+- ENH: MPI transposes use pure derived-datatype `MPI_Alltoallw` operations
+  (no pack/unpack) on host buffers; device buffers use contiguous staging
+  (see above)
 - ENH: The FFT engine verifies at construction that its real- and
   Fourier-space collections use the same storage order
 - ENH: CMake now probes for C++20 standard-library support at configure time

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,37 @@ Change log for µGrid
 0.107.0 (11Jun26)
 -----------------
 
+- ENH: Device halo exchange and FFT transposes now pack into contiguous
+  device staging buffers instead of handing strided MPI derived datatypes
+  to the MPI library (which packs them block by block on device memory,
+  orders of magnitude slower); multi-GPU stencil and FFT operations now
+  scale. Self-neighbor exchanges (periodic directions that are not
+  subdivided) short-circuit to a local device copy
+- ENH: FFT scratch buffers are cached across transforms instead of being
+  allocated per call; together with the removal of two unused
+  construction-time work fields this reduces device memory pressure and
+  eliminates per-transform cudaMalloc latency
+- ENH: `linalg.scal` accepts a real field as the multiplier, broadcast over
+  components (single-component alpha) or applied elementwise (alpha with
+  matching components), on host and device, for real and complex fields
+- ENH: `FourierPreconditioner` and `JacobiPreconditioner` apply through the
+  fused field kernels and run entirely on the device when the solver fields
+  live there; `JacobiPreconditioner` supports per-component diagonals
+- ENH: `muGrid.use_cupy_allocator()` routes all muGrid device allocations
+  through cupy's memory pool so that one allocator owns the GPU; this
+  prevents out-of-memory failures caused by cupy's pool caching memory that
+  muGrid's raw allocator cannot see (`set_device_allocator` provides the
+  generic hook)
+- ENH: `__dlpack__` honours the consumer's `stream` argument (synchronizes
+  for non-default streams)
+- ENH: New `Solvers.ConvergenceError` (a `RuntimeError` subclass) raised on
+  CG non-convergence, so genuine runtime errors (e.g. out of memory) are
+  distinguishable from non-convergence
+- ENH: All CUDA/HIP portability macros consolidated in a single shim header
+  (`memory/gpu_runtime.hh`); duplicated per-backend GPU wrapper code removed
+- ENH: New microbenchmark `benchmarks/communication_benchmark.py` for halo
+  exchange (per split axis) and FFT/transpose timings
+
 - API: `conjugate_gradients` now converges on a relative criterion by
   default, ``||b - Ax|| <= max(rtol * ||b||, atol)`` with ``rtol=1e-6``,
   ``atol=0``; the old absolute `tol` is deprecated (it maps to `atol` with

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,3 +4,21 @@
 ignore:
   - src/libmugrid/fft/rocfft_backend.cc
   - src/libmugrid/fft/rocfft_backend.hh
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        # Tolerate small fluctuations from test reordering and merge timing
+        threshold: 1%
+    patch:
+      default:
+        # A fixed target instead of the "auto" (= project average) default:
+        # GPU code can structurally not reach project-average coverage with
+        # host-only gcov, which cannot instrument CUDA __global__ kernel
+        # bodies, and the device communication code carries per-backend
+        # (CUDA/HIP) and per-MPI-capability (GPU-aware vs host-staged)
+        # branches of which each CI leg can only execute one side.
+        target: 80%
+        threshold: 2%

--- a/doc/source/Examples.rst
+++ b/doc/source/Examples.rst
@@ -176,7 +176,8 @@ implementing this contract:
 - ``JacobiPreconditioner(diagonal)`` — divides by the operator diagonal.
   Useful for strongly heterogeneous coefficients, where it equilibrates the
   spectrum (for a constant diagonal it merely rescales the system and does
-  not change the iteration);
+  not change the iteration). The diagonal may be spatial-only (shared across
+  field components) or per-component;
 - ``FourierPreconditioner(engine, kernel)`` — applies a spectral kernel,
   ``z = F⁻¹[k(q) · F r]``, using a muGrid ``FFTEngine``. With the inverse
   symbol of (an approximation to) the operator as the kernel, this is the
@@ -269,6 +270,12 @@ In the test suite (``tests/python_preconditioner_tests.py``), this reduces
 the iteration count on a 32×32 problem with ``c`` spanning six orders of
 magnitude from 164 to 21; the FFT-preconditioned Poisson solve converges in
 a single iteration.
+
+Both preconditioners run wherever the solver fields live: the Fourier
+kernel and the inverse diagonal are stored in fields on the engine's
+collections and applied with muGrid's fused linear-algebra kernels
+(``linalg.scal`` with a field-valued ``alpha``), so a solve on a GPU
+device stays on the device with no host transfers in the iteration loop.
 
 Linear Elasticity Solver
 ************************

--- a/doc/source/GPU.rst
+++ b/doc/source/GPU.rst
@@ -235,19 +235,11 @@ On NVIDIA GPUs, *µ*\Grid uses the cuFFT library. cuFFT has a **documented limit
     *"Strides on the real part of real-to-complex and complex-to-real transforms
     are not supported."*
 
-This limitation affects **3D MPI-parallel FFTs** on NVIDIA GPUs. In the pencil
-decomposition used for distributed FFTs, the data layout after transpose
-operations results in non-unit strides for the R2C/C2R transforms along the
-X-direction.
-
-**Consequence**: 3D MPI-parallel FFTs on NVIDIA GPUs will raise a ``RuntimeError``
-with a clear explanation of the limitation.
-
-**Workarounds**:
-
-1. Use the CPU FFT backend (PocketFFT) for 3D MPI-parallel transforms
-2. Use 2D grids, which support batched transforms with unit stride
-3. Use single-GPU (non-MPI) execution where the data layout is contiguous
+*µ*\Grid arranges its transform work buffers so that the real-to-complex
+and complex-to-real passes always operate with unit stride (the
+real-space ghost buffers are padded accordingly), so 2D and 3D
+transforms — serial and MPI-parallel — run on cuFFT. The MPI FFT test
+suite exercises these paths on the GPU.
 
 AMD GPUs (rocFFT)
 -----------------
@@ -288,6 +280,95 @@ For code that needs to handle both 2D and 3D cases on GPU:
 
     # Create FFT engine
     engine = muGrid.FFTEngine(nb_grid_pts, device=device)
+
+GPU data and MPI
+****************
+
+Technical background
+--------------------
+
+In MPI-parallel runs, *µ*\Grid has to communicate data that lives in GPU
+memory: ghost (halo) layers of the domain decomposition and the global
+transposes of the distributed FFT. Two properties of MPI implementations
+shape how this is done:
+
+1. **Strided datatypes are slow on device memory.** MPI derived datatypes
+   (``MPI_Type_vector``, subarrays) describe non-contiguous data
+   declaratively, and on host memory implementations handle them well. On
+   device memory, however, common MPI stacks pack such datatypes block by
+   block with one small device copy each — for a halo slice this can mean
+   tens of thousands of 8-byte copies and a slowdown of several orders of
+   magnitude. *µ*\Grid therefore never hands strided device data to MPI:
+   halos and transpose blocks are first gathered into contiguous device
+   staging buffers, sent as flat messages, and scattered on the receiving
+   side.
+
+2. **Not every MPI can read device pointers at all.** Passing a GPU
+   pointer to MPI requires a *GPU-aware* build of the MPI library (e.g.
+   Open MPI/UCX with CUDA support, HPC-X, MVAPICH2-GDR, Cray MPICH with
+   GTL). A plain MPI build — including the stock packages of most Linux
+   distributions — dereferences the pointer on the host and crashes.
+
+Runtime detection and host fallback
+-----------------------------------
+
+*µ*\Grid detects GPU-aware MPI at runtime. With Open MPI (and derivatives
+such as HPC-X), the official ``MPIX_Query_cuda_support()`` /
+``MPIX_Query_rocm_support()`` extensions are queried. For MPI stacks that
+cannot be queried, the conservative answer is *not GPU-aware*.
+
+When MPI is not GPU-aware, the contiguous staging buffers are bounced
+through host memory: pack on the device, copy once to a pinned-size host
+buffer, communicate, copy back, unpack on the device. This is correct
+with any MPI library and, because only flat buffers are copied, costs a
+single device-host round trip per message (measured at roughly 30-40 %
+on the total time of an FFT-preconditioned solve across two GPUs,
+compared to a GPU-aware MPI taking the device pointers directly).
+
+The ``MUGRID_GPU_AWARE_MPI`` environment variable
+-------------------------------------------------
+
+The environment variable ``MUGRID_GPU_AWARE_MPI`` overrides the
+detection in both directions:
+
+* ``MUGRID_GPU_AWARE_MPI=1`` forces direct device pointers. Use this for
+  MPI stacks that are GPU-aware but cannot be queried (e.g. some MPICH
+  derivatives), where detection would needlessly fall back to host
+  staging.
+
+* ``MUGRID_GPU_AWARE_MPI=0`` forces the host bounce — a kill switch for
+  *broken* GPU-aware stacks. GPU support in MPI is a complex, layered
+  feature (UCX transports, IPC, GPUDirect), and real installations have
+  been observed to *silently corrupt* device messages in specific size
+  windows (e.g. UCX's ``cuda_ipc`` transport between consumer GPUs).
+  Forcing the host path trades some bandwidth for transfers that only
+  use plain ``cudaMemcpy``/``hipMemcpy``.
+
+.. code-block:: sh
+
+    # Force the host-staging fallback (kill switch)
+    MUGRID_GPU_AWARE_MPI=0 mpiexec -n 4 python3 my_solver.py
+
+    # Assert that the MPI stack is GPU-aware
+    MUGRID_GPU_AWARE_MPI=1 mpiexec -n 4 python3 my_solver.py
+
+Validating an installation
+--------------------------
+
+If you suspect the MPI/GPU stack, two quick checks help:
+
+* Run the MPI test suite on the GPU device::
+
+      mpiexec -n 2 python3 -m pytest tests/python_mpi_fft_tests.py -k gpu
+
+  with and without ``MUGRID_GPU_AWARE_MPI=0``. If results differ, the
+  GPU-aware path of your MPI installation is broken; keep the kill
+  switch on and report the issue to your MPI/UCX vendor.
+
+* Time the communication primitives with
+  ``benchmarks/communication_benchmark.py`` (per-axis halo exchange and
+  FFT/transpose timings). Per-call halo times should be milliseconds;
+  much larger values indicate that messages take a slow path.
 
 Performance considerations
 **************************

--- a/doc/source/LinAlg.rst
+++ b/doc/source/LinAlg.rst
@@ -43,6 +43,11 @@ The following operations are available in the ``muGrid.linalg`` namespace
    * - ``scal(alpha, x)``
      - :math:`x \leftarrow \alpha x`
      - SSCAL / DSCAL
+   * - ``scal(alpha_field, x)``
+     - :math:`x_{c,i} \leftarrow \alpha_{c,i}\, x_{c,i}` (per-pixel
+       multiplier; single-component :math:`\alpha` broadcasts over the
+       components of :math:`x`)
+     - (extended BLAS)
    * - ``axpby(alpha, x, beta, y)``
      - :math:`y \leftarrow \alpha x + \beta y`
      - (extended BLAS)
@@ -135,6 +140,15 @@ module:
 
     # Scale: x = 2.0 * x
     la.scal(2.0, x)
+
+    # Scale by a per-pixel multiplier (e.g. an inverse operator diagonal
+    # or a spectral kernel); alpha is a real field on the same collection.
+    # A single-component alpha broadcasts over the components of x; an
+    # alpha with x's number of components is applied elementwise. x may
+    # be real or complex.
+    alpha = fc.real_field("alpha")
+    alpha.p[...] = 0.5
+    la.scal(alpha, x)
 
     # Squared norm
     norm2 = la.norm_sq(x)

--- a/language_bindings/python/CMakeLists.txt
+++ b/language_bindings/python/CMakeLists.txt
@@ -85,6 +85,7 @@ install(TARGETS _muGrid
 # Install pure Python files
 install(FILES
     muGrid/__init__.py
+    muGrid/DeviceMemory.py
     muGrid/Field.py
     muGrid/linalg.py
     muGrid/Parallel.py

--- a/language_bindings/python/bind_py_device.cc
+++ b/language_bindings/python/bind_py_device.cc
@@ -33,9 +33,12 @@
  *
  */
 
+#include <cstdint>
+
 #include <pybind11/pybind11.h>
 
 #include "memory/device.hh"
+#include "memory/device_alloc.hh"
 
 using muGrid::Device;
 using muGrid::DeviceType;
@@ -43,7 +46,90 @@ using pybind11::literals::operator""_a;
 
 namespace py = pybind11;
 
+namespace {
+
+    // Python-callable device allocator hook. The C++ hook is a plain
+    // function pointer, so the Python callables live in statics and the
+    // trampolines re-acquire the GIL (muGrid may allocate from code that
+    // runs without it). The holders are heap-allocated and intentionally
+    // leaked so that no py::object destructor runs after interpreter
+    // finalization.
+    py::object & py_device_allocate() {
+        static py::object * holder{new py::object{}};
+        return *holder;
+    }
+
+    py::object & py_device_deallocate() {
+        static py::object * holder{new py::object{}};
+        return *holder;
+    }
+
+    void * device_allocate_trampoline(std::size_t bytes) {
+        if (!Py_IsInitialized()) {
+            return nullptr;
+        }
+        py::gil_scoped_acquire gil{};
+        try {
+            return reinterpret_cast<void *>(
+                py_device_allocate()(bytes).cast<std::uintptr_t>());
+        } catch (py::error_already_set &) {
+            // Out of memory (or any other failure) in the external
+            // allocator; device_allocate() turns nullptr into a
+            // RuntimeError.
+            return nullptr;
+        }
+    }
+
+    void device_deallocate_trampoline(void * ptr) {
+        if (!Py_IsInitialized()) {
+            // Interpreter is gone; the pool it would return to no longer
+            // exists. Intentional leak at shutdown.
+            return;
+        }
+        py::gil_scoped_acquire gil{};
+        try {
+            py_device_deallocate()(reinterpret_cast<std::uintptr_t>(ptr));
+        } catch (py::error_already_set & e) {
+            e.discard_as_unraisable("muGrid device deallocate hook");
+        }
+    }
+
+}  // namespace
+
 void add_device_classes(py::module & mod) {
+    mod.def(
+        "set_device_allocator",
+        [](py::object allocate, py::object deallocate) {
+            py_device_allocate() = std::move(allocate);
+            py_device_deallocate() = std::move(deallocate);
+            muGrid::set_device_allocator(device_allocate_trampoline,
+                                         device_deallocate_trampoline);
+        },
+        "allocate"_a, "deallocate"_a,
+        R"pbdoc(
+        Register an external device allocator for all muGrid device memory.
+
+        ``allocate(nbytes) -> int`` must return a device pointer (as an
+        integer) to at least ``nbytes`` bytes and keep the underlying
+        allocation alive until ``deallocate(ptr)`` is called with the same
+        integer. Use :func:`muGrid.use_cupy_allocator` for the common case
+        of routing through cupy's memory pool, so that one allocator owns
+        the GPU and muGrid allocations cannot be starved by pool caching.
+        )pbdoc");
+    mod.def(
+        "clear_device_allocator",
+        []() {
+            muGrid::set_device_allocator(nullptr, nullptr);
+            py_device_allocate() = py::object{};
+            py_device_deallocate() = py::object{};
+        },
+        R"pbdoc(
+        Restore the default (raw cudaMalloc/hipMalloc) device allocator.
+
+        Allocations made through a previously registered allocator are
+        still freed through it; only new allocations use the default.
+        )pbdoc");
+
     // Device type enumeration
     py::enum_<DeviceType>(mod, "DeviceType",
         R"pbdoc(

--- a/language_bindings/python/bind_py_field.cc
+++ b/language_bindings/python/bind_py_field.cc
@@ -41,6 +41,7 @@
 #include "collection/field_collection.hh"
 #include "collection/field_collection_global.hh"
 #include "field/mapped_field.hh"
+#include "memory/gpu_runtime.hh"
 
 #include <dlpack/dlpack.h>
 
@@ -401,7 +402,15 @@ void add_typed_field_device(py::module &mod, std::string name) {
             .def(
                 "__dlpack__",
                 [](py::object self_obj, py::object stream) {
-                    (void)stream;  // TODO: support CUDA stream for async transfers
+                    // muGrid issues all device work on the legacy default
+                    // stream. If the consumer passes a different stream
+                    // (anything but None or the legacy default handle 1),
+                    // make the data visible to it by synchronizing the
+                    // device. Conservative but correct; consumers on the
+                    // default stream pay nothing.
+                    if (!stream.is_none() && py::cast<long long>(stream) != 1) {
+                        GPU_DEVICE_SYNCHRONIZE();
+                    }
                     auto &self = self_obj.cast<TypedFieldBase<T, DeviceSpace> &>();
                     return create_dlpack_capsule(self, self_obj);
                 },

--- a/language_bindings/python/bind_py_linalg.cc
+++ b/language_bindings/python/bind_py_linalg.cc
@@ -267,6 +267,25 @@ void add_linalg_functions(py::module &mod) {
         "alpha"_a, "x"_a, "y"_a,
         "Fused AXPY + norm_sq for complex fields: y = alpha * x + y, returns ||y||².");
 
+    linalg.def("pointwise_scale",
+        static_cast<void (*)(ComplexFieldHost&, const RealFieldHost&)>(
+            &muGrid::linalg::pointwise_scale<HostSpace>),
+        "x"_a, "kernel"_a,
+        R"pbdoc(
+        Pointwise spectral scale: x[c, i] *= kernel[i] for every component c.
+
+        Multiplies each component of a complex field elementwise by a
+        single-component real field on the same collection (e.g. the
+        inverse symbol of an operator in a Fourier-space preconditioner).
+
+        Parameters
+        ----------
+        x : ComplexField
+            Complex input/output field (modified in place)
+        kernel : RealField
+            Real single-component field of multipliers
+        )pbdoc");
+
 #if defined(MUGRID_ENABLE_CUDA) || defined(MUGRID_ENABLE_HIP)
     // --- Real field operations (device) ---
 
@@ -311,6 +330,12 @@ void add_linalg_functions(py::module &mod) {
             &muGrid::linalg::axpy_norm_sq<Real, DeviceSpace>),
         "alpha"_a, "x"_a, "y"_a,
         "Fused AXPY + norm_sq on device (GPU): y = alpha * x + y, returns ||y||².");
+
+    linalg.def("pointwise_scale",
+        static_cast<void (*)(ComplexFieldDevice&, const RealFieldDevice&)>(
+            &muGrid::linalg::pointwise_scale<DeviceSpace>),
+        "x"_a, "kernel"_a,
+        "Pointwise spectral scale on device (GPU): x[c, i] *= kernel[i].");
 
     // --- Complex field operations (device) ---
 

--- a/language_bindings/python/bind_py_linalg.cc
+++ b/language_bindings/python/bind_py_linalg.cc
@@ -267,23 +267,43 @@ void add_linalg_functions(py::module &mod) {
         "alpha"_a, "x"_a, "y"_a,
         "Fused AXPY + norm_sq for complex fields: y = alpha * x + y, returns ||y||².");
 
-    linalg.def("pointwise_scale",
-        static_cast<void (*)(ComplexFieldHost&, const RealFieldHost&)>(
-            &muGrid::linalg::pointwise_scale<HostSpace>),
-        "x"_a, "kernel"_a,
+    linalg.def("scal",
+        static_cast<void (*)(const RealFieldHost&, ComplexFieldHost&)>(
+            &muGrid::linalg::scal<HostSpace>),
+        "alpha"_a, "x"_a,
         R"pbdoc(
-        Pointwise spectral scale: x[c, i] *= kernel[i] for every component c.
+        Scale operation with per-pixel multiplier: x[c, i] *= alpha[c, i].
 
-        Multiplies each component of a complex field elementwise by a
-        single-component real field on the same collection (e.g. the
-        inverse symbol of an operator in a Fourier-space preconditioner).
+        Overload of scal() where alpha is a real field on the same
+        collection. A single-component alpha is broadcast over the
+        components of x (e.g. the inverse symbol of an operator in a
+        Fourier-space preconditioner); an alpha with x's number of
+        components is applied elementwise.
 
         Parameters
         ----------
+        alpha : RealField
+            Real field of multipliers (1 or x's number of components)
         x : ComplexField
             Complex input/output field (modified in place)
-        kernel : RealField
-            Real single-component field of multipliers
+        )pbdoc");
+
+    linalg.def("scal",
+        static_cast<void (*)(const RealFieldHost&, RealFieldHost&)>(
+            &muGrid::linalg::scal<HostSpace>),
+        "alpha"_a, "x"_a,
+        R"pbdoc(
+        Scale operation with per-pixel multiplier: x[c, i] *= alpha[c, i].
+
+        Real-field variant; together with copy() this runs a Jacobi
+        preconditioner (z = D^-1 r) without leaving the field's device.
+
+        Parameters
+        ----------
+        alpha : RealField
+            Real field of multipliers (1 or x's number of components)
+        x : RealField
+            Real input/output field (modified in place)
         )pbdoc");
 
 #if defined(MUGRID_ENABLE_CUDA) || defined(MUGRID_ENABLE_HIP)
@@ -331,11 +351,19 @@ void add_linalg_functions(py::module &mod) {
         "alpha"_a, "x"_a, "y"_a,
         "Fused AXPY + norm_sq on device (GPU): y = alpha * x + y, returns ||y||².");
 
-    linalg.def("pointwise_scale",
-        static_cast<void (*)(ComplexFieldDevice&, const RealFieldDevice&)>(
-            &muGrid::linalg::pointwise_scale<DeviceSpace>),
-        "x"_a, "kernel"_a,
-        "Pointwise spectral scale on device (GPU): x[c, i] *= kernel[i].");
+    linalg.def("scal",
+        static_cast<void (*)(const RealFieldDevice&, ComplexFieldDevice&)>(
+            &muGrid::linalg::scal<DeviceSpace>),
+        "alpha"_a, "x"_a,
+        "Scale by a per-pixel real field on device (GPU): "
+        "x[c, i] *= alpha[c, i].");
+
+    linalg.def("scal",
+        static_cast<void (*)(const RealFieldDevice&, RealFieldDevice&)>(
+            &muGrid::linalg::scal<DeviceSpace>),
+        "alpha"_a, "x"_a,
+        "Scale a real field by a per-pixel real field on device (GPU): "
+        "x[c, i] *= alpha[c, i].");
 
     // --- Complex field operations (device) ---
 

--- a/language_bindings/python/muGrid/DeviceMemory.py
+++ b/language_bindings/python/muGrid/DeviceMemory.py
@@ -1,0 +1,50 @@
+"""
+Device memory allocator integration.
+
+muGrid's C++ core allocates GPU memory with raw cudaMalloc/hipMalloc,
+while Python-side array libraries like cupy draw from a caching memory
+pool that never returns freed blocks to the driver. Two independent
+allocators on one device starve each other: near capacity, muGrid's raw
+allocation fails even though plenty of memory sits "free" inside the
+pool. Registering cupy's allocator with muGrid makes one allocator own
+every device byte and removes this failure mode by construction.
+"""
+
+from . import _muGrid
+
+
+def use_cupy_allocator():
+    """
+    Route all muGrid device allocations through cupy's memory pool.
+
+    Call this once, before creating GPU field collections, in programs
+    that use both muGrid GPU fields and cupy arrays::
+
+        import muGrid
+        muGrid.use_cupy_allocator()
+        fc = muGrid.GlobalFieldCollection(nb_grid_pts, device=muGrid.Device.gpu())
+
+    Works with both CUDA and ROCm builds of cupy. Call
+    :func:`muGrid.clear_device_allocator` to restore the default
+    allocator (allocations made in the meantime are still freed through
+    the pool).
+    """
+    import cupy
+
+    # Keep the MemoryPointer objects alive until muGrid frees them; the
+    # integer pointer value is the lookup key.
+    keepalive = {}
+
+    def allocate(nbytes):
+        mem = cupy.cuda.alloc(nbytes)
+        keepalive[int(mem.ptr)] = mem
+        return int(mem.ptr)
+
+    def deallocate(ptr):
+        keepalive.pop(int(ptr), None)
+
+    _muGrid.set_device_allocator(allocate, deallocate)
+
+
+set_device_allocator = _muGrid.set_device_allocator
+clear_device_allocator = _muGrid.clear_device_allocator

--- a/language_bindings/python/muGrid/Preconditioners.py
+++ b/language_bindings/python/muGrid/Preconditioners.py
@@ -20,6 +20,20 @@ from contextlib import nullcontext
 import numpy as np
 
 from . import linalg
+from .Field import wrap_field
+
+
+def _fill_field(field, values):
+    """Assign host values to the interior view of a host or device field."""
+    s = field.s
+    try:
+        s[...] = values
+    except (TypeError, ValueError):
+        # Device view: cupy's __setitem__ does not accept numpy sources;
+        # convert once (setup time only).
+        import cupy
+
+        s[...] = cupy.asarray(values)
 
 
 class Preconditioner:
@@ -65,16 +79,23 @@ class JacobiPreconditioner(Preconditioner):
     Laplacian, Jacobi only rescales the system and does not change the CG
     iteration.)
 
+    The preconditioner runs wherever the solver fields live: the inverse
+    diagonal is stored in a field on the residual's collection (created on
+    first application) and applied with the fused ``linalg.copy`` +
+    ``linalg.scal`` kernels, on host and device alike.
+
     Parameters
     ----------
     diagonal : muGrid.Field, array-like or scalar
         Diagonal entries of the system operator on the local subdomain.
-        Either a field created on the same collection as the solver fields,
-        an array broadcastable against the interior field values (shape
-        ``(*spatial,)`` to share one diagonal across components, or
+        Either a field created on the same collection as the solver fields
+        (host or device), an array matching the interior field values
+        (shape ``(*spatial,)`` to share one diagonal across components, or
         ``(*components, *spatial)`` for per-component entries), or a
         scalar. The entries are inverted once at construction; the values
         are copied, later modification of the source has no effect.
+    name : str, optional
+        Prefix for the field holding the inverse diagonal.
 
     Raises
     ------
@@ -82,19 +103,57 @@ class JacobiPreconditioner(Preconditioner):
         If any diagonal entry is zero.
     """
 
-    def __init__(self, diagonal):
+    def __init__(self, diagonal, name="jacobi-preconditioner"):
+        self._name = name
         values = getattr(diagonal, "s", None)  # muGrid field?
-        if values is None:
+        if values is not None:
+            # Device fields expose cupy views; pull a host copy
+            values = values.get() if hasattr(values, "get") else np.array(values)
+        else:
             values = np.asarray(diagonal, dtype=float)
-        if not (abs(values) > 0).all():
+        if not (np.abs(values) > 0).all():
             raise ValueError(
                 "Jacobi preconditioner requires a non-singular diagonal "
                 "(got entries equal to zero)"
             )
-        self._inverse_diagonal = 1.0 / values
+        self._is_scalar = values.ndim == 0
+        self._inverse_diagonal = (
+            1.0 / float(values) if self._is_scalar else 1.0 / values
+        )
+        self._field = None
+
+    def _inverse_diagonal_field(self, z):
+        """Field holding D⁻¹ on z's collection (created on first use)."""
+        if self._field is None:
+            values = self._inverse_diagonal
+            # Spatial-only diagonals go into a single-component field that
+            # linalg.scal broadcasts over z's components; values that do
+            # not fit the spatial shape are per-component diagonals.
+            nb_component_axes = len(tuple(z.components_shape))
+            spatial_shape = tuple(z.s.shape)[nb_component_axes:]
+            try:
+                np.broadcast_to(values, spatial_shape)
+                components = ()
+            except ValueError:
+                components = tuple(z.components_shape)
+            field = wrap_field(
+                z.collection.real_field(
+                    f"{self._name}-inverse-diagonal", components
+                )
+            )
+            # scal operates on the full buffer; zero ghost entries keep
+            # the (later overwritten) ghost values of z finite.
+            field.set_zero()
+            _fill_field(field, np.broadcast_to(values, field.s.shape))
+            self._field = field
+        return self._field
 
     def apply(self, r, z):
-        z.s[...] = r.s * self._inverse_diagonal
+        linalg.copy(r, z)
+        if self._is_scalar:
+            linalg.scal(self._inverse_diagonal, z)
+        else:
+            linalg.scal(self._inverse_diagonal_field(z), z)
 
 
 class FourierPreconditioner(Preconditioner):
@@ -171,7 +230,7 @@ class FourierPreconditioner(Preconditioner):
         # Store the kernel in a real field on the engine's Fourier
         # collection (host or device, matching the work fields) and fold
         # the inverse-transform normalisation in, so apply() is a single
-        # linalg.pointwise_scale with no array-library dependence in the
+        # linalg.scal with no array-library dependence in the
         # hot loop.
         self._kernel_field = engine.fourier_space_collection.real_field(
             f"{name}-kernel"
@@ -213,6 +272,6 @@ class FourierPreconditioner(Preconditioner):
         # Fused C++ kernel, host or device; broadcasts over components and
         # has the inverse-transform normalisation folded in.
         with self._timed("scale"):
-            linalg.pointwise_scale(work, self._kernel_field)
+            linalg.scal(self._kernel_field, work)
         with self._timed("ifft"):
             engine.ifft(work, z)

--- a/language_bindings/python/muGrid/Preconditioners.py
+++ b/language_bindings/python/muGrid/Preconditioners.py
@@ -168,9 +168,24 @@ class FourierPreconditioner(Preconditioner):
                 f"Fourier subdomain {expected} of the FFT engine"
             )
 
-        # Fold the inverse-transform normalisation into the kernel so apply()
-        # is a single pointwise multiplication.
-        self._kernel = kernel * engine.normalisation
+        # Store the kernel in a real field on the engine's Fourier
+        # collection (host or device, matching the work fields) and fold
+        # the inverse-transform normalisation in, so apply() is a single
+        # linalg.pointwise_scale with no array-library dependence in the
+        # hot loop.
+        self._kernel_field = engine.fourier_space_collection.real_field(
+            f"{name}-kernel"
+        )
+        values = kernel * engine.normalisation
+        s = self._kernel_field.s
+        try:
+            s[...] = values
+        except (TypeError, ValueError):
+            # Device view: cupy's __setitem__ does not accept numpy
+            # sources; convert once at setup.
+            import cupy
+
+            s[...] = cupy.asarray(values)
 
     def _work_field(self, components_shape):
         key = tuple(components_shape)
@@ -195,19 +210,9 @@ class FourierPreconditioner(Preconditioner):
         engine = self._engine
         with self._timed("fft"):
             engine.fft(r, work)
-        s = work.s
-        kernel = self._kernel
-        if type(s).__module__.partition(".")[0] == "cupy":
-            # Device fields: move the kernel over once, lazily.
-            import cupy
-
-            kernel = cupy.asarray(kernel)
-            self._kernel = kernel
-        # Broadcasts over leading component axes; normalisation is folded in.
-        # In-place multiply on the view, NOT `s[...] *= kernel`: cupy's
-        # __setitem__ materialises a contiguous copy of the whole strided
-        # field (1 GiB at 512^3).
+        # Fused C++ kernel, host or device; broadcasts over components and
+        # has the inverse-transform normalisation folded in.
         with self._timed("scale"):
-            s *= kernel
+            linalg.pointwise_scale(work, self._kernel_field)
         with self._timed("ifft"):
             engine.ifft(work, z)

--- a/language_bindings/python/muGrid/__init__.py
+++ b/language_bindings/python/muGrid/__init__.py
@@ -64,6 +64,11 @@ device_arch = _muGrid.device_arch
 Device = _muGrid.Device
 DeviceType = _muGrid.DeviceType
 
+from .DeviceMemory import (  # noqa: F401, E402
+    clear_device_allocator,
+    set_device_allocator,
+    use_cupy_allocator,
+)
 
 # Cache for runtime GPU availability check
 _gpu_available_cache = None

--- a/language_bindings/python/muGrid/linalg.py
+++ b/language_bindings/python/muGrid/linalg.py
@@ -167,3 +167,22 @@ def axpy_norm_sq(alpha, x, y):
 
 
 __all__ = ["vecdot", "norm_sq", "axpy", "scal", "axpby", "copy", "axpy_norm_sq"]
+
+
+def pointwise_scale(x, kernel):
+    """
+    Pointwise spectral scale: ``x[c, i] *= kernel[i]`` for every component.
+
+    Multiplies each component of a complex field elementwise by a
+    single-component real field on the same collection, e.g. the inverse
+    symbol of an operator in a Fourier-space preconditioner. Works on host
+    and device fields.
+
+    Parameters
+    ----------
+    x : Field
+        Complex input/output field (modified in place)
+    kernel : Field
+        Real single-component field of multipliers
+    """
+    _linalg.pointwise_scale(_get_cpp(x), _get_cpp(kernel))

--- a/language_bindings/python/muGrid/linalg.py
+++ b/language_bindings/python/muGrid/linalg.py
@@ -94,14 +94,26 @@ def scal(alpha, x):
     """
     Scale operation: x = alpha * x (full buffer).
 
+    Following BLAS *scal, but alpha may also be a real field on the same
+    collection, applied per pixel: a single-component alpha is broadcast
+    over the components of x (e.g. the inverse symbol of an operator in
+    a Fourier-space preconditioner), an alpha with x's number of
+    components is applied elementwise (e.g. a per-component Jacobi
+    diagonal). Works on host and device fields; x may be real or
+    complex.
+
     Parameters
     ----------
-    alpha : float or complex
-        Scalar multiplier
+    alpha : float, complex or Field
+        Scalar multiplier, or a real field of per-pixel multipliers with
+        one or x's number of components
     x : Field
         Input/output field (modified in place)
     """
-    _linalg.scal(alpha, _get_cpp(x))
+    if hasattr(alpha, "_cpp") or not isinstance(alpha, (int, float, complex)):
+        _linalg.scal(_get_cpp(alpha), _get_cpp(x))
+    else:
+        _linalg.scal(alpha, _get_cpp(x))
 
 
 def axpby(alpha, x, beta, y):
@@ -167,22 +179,3 @@ def axpy_norm_sq(alpha, x, y):
 
 
 __all__ = ["vecdot", "norm_sq", "axpy", "scal", "axpby", "copy", "axpy_norm_sq"]
-
-
-def pointwise_scale(x, kernel):
-    """
-    Pointwise spectral scale: ``x[c, i] *= kernel[i]`` for every component.
-
-    Multiplies each component of a complex field elementwise by a
-    single-component real field on the same collection, e.g. the inverse
-    symbol of an operator in a Fourier-space preconditioner. Works on host
-    and device fields.
-
-    Parameters
-    ----------
-    x : Field
-        Complex input/output field (modified in place)
-    kernel : Field
-        Real single-component field of multipliers
-    """
-    _linalg.pointwise_scale(_get_cpp(x), _get_cpp(kernel))

--- a/src/libmugrid/CMakeLists.txt
+++ b/src/libmugrid/CMakeLists.txt
@@ -53,6 +53,7 @@ set(MUGRID_SOURCES
     io/file_io_base.cc
     # memory/
     memory/device.cc
+    memory/device_alloc.cc
     # util/
     # linalg/
     linalg/linalg_host.cc

--- a/src/libmugrid/CMakeLists.txt
+++ b/src/libmugrid/CMakeLists.txt
@@ -54,6 +54,7 @@ set(MUGRID_SOURCES
     # memory/
     memory/device.cc
     memory/device_alloc.cc
+    mpi/gpu_aware_mpi.cc
     # util/
     # linalg/
     linalg/linalg_host.cc

--- a/src/libmugrid/fft/fft_engine_base.cc
+++ b/src/libmugrid/fft/fft_engine_base.cc
@@ -334,7 +334,8 @@ Transpose * FFTEngineBase::get_transpose_xy(Index_t nb_components,
 
   auto transpose = std::make_unique<Transpose>(
       comm, cfg.local_in, cfg.local_out, cfg.global_in, cfg.global_out,
-      cfg.axis_in, cfg.axis_out, nb_components, layout);
+      cfg.axis_in, cfg.axis_out, nb_components, layout,
+      this->get_device().is_device());
 
   auto * ptr = transpose.get();
   this->transpose_xy_cache[key] = std::move(transpose);
@@ -359,7 +360,8 @@ Transpose * FFTEngineBase::get_transpose_yz(Index_t nb_components,
 
   auto transpose = std::make_unique<Transpose>(
       comm, cfg.local_in, cfg.local_out, cfg.global_in, cfg.global_out,
-      cfg.axis_in, cfg.axis_out, nb_components, layout);
+      cfg.axis_in, cfg.axis_out, nb_components, layout,
+      this->get_device().is_device());
 
   auto * ptr = transpose.get();
   this->transpose_yz_cache[key] = std::move(transpose);

--- a/src/libmugrid/fft/transpose.cc
+++ b/src/libmugrid/fft/transpose.cc
@@ -5,7 +5,8 @@
  *
  * @date   21 Dec 2025
  *
- * @brief  MPI transpose using derived datatypes (no explicit pack/unpack)
+ * @brief  MPI transpose: derived datatypes on host, contiguous staging
+ *         on device
  *
  * Copyright © 2024 Lars Pastewka
  *
@@ -104,75 +105,6 @@ namespace muGrid {
             this->types_initialized = true;
         }
 #endif
-    }
-
-    Transpose::Transpose(Transpose && other) noexcept
-        : comm{std::move(other.comm)}, local_in{std::move(other.local_in)},
-          local_out{std::move(other.local_out)}, global_in{other.global_in},
-          global_out{other.global_out}, axis_in{other.axis_in},
-          axis_out{other.axis_out}, nb_components{other.nb_components},
-          layout{other.layout}, in_counts{std::move(other.in_counts)},
-          in_displs{std::move(other.in_displs)},
-          out_counts{std::move(other.out_counts)},
-          out_displs{std::move(other.out_displs)}
-#ifdef WITH_MPI
-          ,
-          send_types_fwd{std::move(other.send_types_fwd)},
-          recv_types_fwd{std::move(other.recv_types_fwd)},
-          send_types_bwd{std::move(other.send_types_bwd)},
-          recv_types_bwd{std::move(other.recv_types_bwd)},
-          send_counts{std::move(other.send_counts)},
-          recv_counts{std::move(other.recv_counts)},
-          send_displs{std::move(other.send_displs)},
-          recv_displs{std::move(other.recv_displs)}
-#endif
-          ,
-          types_initialized{other.types_initialized},
-          on_device{other.on_device}, device_staging{other.device_staging},
-          device_staging_size{other.device_staging_size} {
-        other.types_initialized = false;  // Prevent double-free
-        other.device_staging = {{nullptr, nullptr}};
-        other.device_staging_size = {{0, 0}};
-    }
-
-    Transpose & Transpose::operator=(Transpose && other) noexcept {
-        if (this != &other) {
-#ifdef WITH_MPI
-            free_datatypes();
-#endif
-            comm = std::move(other.comm);
-            local_in = std::move(other.local_in);
-            local_out = std::move(other.local_out);
-            global_in = other.global_in;
-            global_out = other.global_out;
-            axis_in = other.axis_in;
-            axis_out = other.axis_out;
-            nb_components = other.nb_components;
-            layout = other.layout;
-            in_counts = std::move(other.in_counts);
-            in_displs = std::move(other.in_displs);
-            out_counts = std::move(other.out_counts);
-            out_displs = std::move(other.out_displs);
-#ifdef WITH_MPI
-            send_types_fwd = std::move(other.send_types_fwd);
-            recv_types_fwd = std::move(other.recv_types_fwd);
-            send_types_bwd = std::move(other.send_types_bwd);
-            recv_types_bwd = std::move(other.recv_types_bwd);
-            send_counts = std::move(other.send_counts);
-            recv_counts = std::move(other.recv_counts);
-            send_displs = std::move(other.send_displs);
-            recv_displs = std::move(other.recv_displs);
-#endif
-            types_initialized = other.types_initialized;
-            other.types_initialized = false;
-            this->free_staging();
-            on_device = other.on_device;
-            device_staging = other.device_staging;
-            device_staging_size = other.device_staging_size;
-            other.device_staging = {{nullptr, nullptr}};
-            other.device_staging_size = {{0, 0}};
-        }
-        return *this;
     }
 
     void Transpose::free_staging() {

--- a/src/libmugrid/fft/transpose.cc
+++ b/src/libmugrid/fft/transpose.cc
@@ -35,6 +35,8 @@
 
 #include "transpose.hh"
 #include "core/exception.hh"
+#include "memory/device_alloc.hh"
+#include "memory/gpu_runtime.hh"
 
 #include <algorithm>
 #include <numeric>
@@ -64,10 +66,12 @@ namespace muGrid {
                          const DynGridIndex & local_in,
                          const DynGridIndex & local_out, Index_t global_in,
                          Index_t global_out, Index_t axis_in, Index_t axis_out,
-                         Index_t nb_components, StorageOrder layout)
+                         Index_t nb_components, StorageOrder layout,
+                         bool on_device)
         : comm{comm}, local_in{local_in}, local_out{local_out},
           global_in{global_in}, global_out{global_out}, axis_in{axis_in},
-          axis_out{axis_out}, nb_components{nb_components}, layout{layout} {
+          axis_out{axis_out}, nb_components{nb_components}, layout{layout},
+          on_device{on_device} {
         if (local_in.get_dim() != local_out.get_dim()) {
             throw RuntimeError(
                 "Input and output must have same dimensionality");
@@ -123,8 +127,12 @@ namespace muGrid {
           recv_displs{std::move(other.recv_displs)}
 #endif
           ,
-          types_initialized{other.types_initialized} {
+          types_initialized{other.types_initialized},
+          on_device{other.on_device}, device_staging{other.device_staging},
+          device_staging_size{other.device_staging_size} {
         other.types_initialized = false;  // Prevent double-free
+        other.device_staging = {{nullptr, nullptr}};
+        other.device_staging_size = {{0, 0}};
     }
 
     Transpose & Transpose::operator=(Transpose && other) noexcept {
@@ -157,14 +165,31 @@ namespace muGrid {
 #endif
             types_initialized = other.types_initialized;
             other.types_initialized = false;
+            this->free_staging();
+            on_device = other.on_device;
+            device_staging = other.device_staging;
+            device_staging_size = other.device_staging_size;
+            other.device_staging = {{nullptr, nullptr}};
+            other.device_staging_size = {{0, 0}};
         }
         return *this;
+    }
+
+    void Transpose::free_staging() {
+        for (auto & buffer : this->device_staging) {
+            if (buffer != nullptr) {
+                device_deallocate(buffer);
+                buffer = nullptr;
+            }
+        }
+        this->device_staging_size = {{0, 0}};
     }
 
     Transpose::~Transpose() {
 #ifdef WITH_MPI
         free_datatypes();
 #endif
+        this->free_staging();
     }
 
 #ifdef WITH_MPI
@@ -427,6 +452,216 @@ namespace muGrid {
                 this->local_in, recv_block_shape, recv_block_start);
         }
     }
+
+    namespace {
+        //! Device-to-device strided 2D copy (pack/unpack building block)
+        void strided_device_copy(void * dst, const void * src,
+                                 std::size_t width_bytes, std::size_t nb_rows,
+                                 std::size_t dst_pitch_bytes,
+                                 std::size_t src_pitch_bytes) {
+#if defined(MUGRID_ENABLE_CUDA) || defined(MUGRID_ENABLE_HIP)
+            GPU_MEMCPY_2D_D2D(dst, dst_pitch_bytes, src, src_pitch_bytes,
+                              width_bytes, nb_rows);
+#else
+            (void)dst;
+            (void)src;
+            (void)width_bytes;
+            (void)nb_rows;
+            (void)dst_pitch_bytes;
+            (void)src_pitch_bytes;
+            throw RuntimeError("Transpose: device data requires a GPU build");
+#endif
+        }
+    }  // namespace
+
+    char * Transpose::get_device_staging(std::size_t slot,
+                                         std::size_t size) const {
+        auto & buffer{this->device_staging.at(slot)};
+        auto & current_size{this->device_staging_size.at(slot)};
+        if (current_size < size) {
+            if (buffer != nullptr) {
+                device_deallocate(buffer);
+                buffer = nullptr;
+                current_size = 0;
+            }
+            buffer = device_allocate(size);
+            current_size = size;
+        }
+        return static_cast<char *>(buffer);
+    }
+
+    void Transpose::staged_alltoall(
+        const Complex * input, Complex * output, const DynGridIndex & src_shape,
+        Index_t src_axis, const std::vector<Index_t> & src_counts,
+        const std::vector<Index_t> & src_displs, const DynGridIndex & dst_shape,
+        Index_t dst_axis, const std::vector<Index_t> & dst_counts,
+        const std::vector<Index_t> & dst_displs) const {
+        int comm_size{this->comm.size()};
+
+        // Geometry of a column-major subarray block that is full in all
+        // dimensions except `axis`: the block occupies contiguous runs of
+        // pre*count elements (pre = product of extents below `axis`),
+        // repeated post times (post = product of extents above `axis`) with
+        // a uniform stride of pre*extent(axis). Serializing it row by row
+        // reproduces exactly the canonical (column-major) subarray order
+        // that MPI_Type_create_subarray uses, so the staged exchange is
+        // wire-compatible with the datatype-based host path.
+        auto pre_post{[](const DynGridIndex & shape, Index_t axis) {
+            std::size_t pre{1}, post{1};
+            for (Dim_t d{0}; d < shape.get_dim(); ++d) {
+                if (d < axis) {
+                    pre *= shape[d];
+                } else if (d > axis) {
+                    post *= shape[d];
+                }
+            }
+            return std::make_pair(pre, post);
+        }};
+        auto [src_pre, src_post] = pre_post(src_shape, src_axis);
+        auto [dst_pre, dst_post] = pre_post(dst_shape, dst_axis);
+        std::size_t src_spatial{src_pre * src_shape[src_axis] * src_post};
+        std::size_t dst_spatial{dst_pre * dst_shape[dst_axis] * dst_post};
+        auto ncomp{static_cast<std::size_t>(this->nb_components)};
+        bool aos{this->layout == StorageOrder::ArrayOfStructures};
+
+        // Per-peer element counts (in units of Complex) and displacements
+        std::vector<int> send_counts_el(comm_size), send_displs_el(comm_size);
+        std::vector<int> recv_counts_el(comm_size), recv_displs_el(comm_size);
+        std::size_t send_total{0}, recv_total{0};
+        for (int r{0}; r < comm_size; ++r) {
+            std::size_t s{src_pre * src_counts[r] * src_post * ncomp};
+            std::size_t d{dst_pre * dst_counts[r] * dst_post * ncomp};
+            send_counts_el[r] = static_cast<int>(s);
+            send_displs_el[r] = static_cast<int>(send_total);
+            recv_counts_el[r] = static_cast<int>(d);
+            recv_displs_el[r] = static_cast<int>(recv_total);
+            send_total += s;
+            recv_total += d;
+        }
+
+        char * send_staging{
+            this->get_device_staging(0, send_total * sizeof(Complex))};
+        char * recv_staging{
+            this->get_device_staging(1, recv_total * sizeof(Complex))};
+
+        // Pack: gather each peer's block into the contiguous send buffer
+        for (int r{0}; r < comm_size; ++r) {
+            if (src_counts[r] == 0) {
+                continue;
+            }
+            auto * staging{send_staging +
+                           static_cast<std::size_t>(send_displs_el[r]) *
+                               sizeof(Complex)};
+            if (aos) {
+                std::size_t width{src_pre * src_counts[r] * ncomp *
+                                  sizeof(Complex)};
+                std::size_t pitch{src_pre * src_shape[src_axis] * ncomp *
+                                  sizeof(Complex)};
+                const Complex * field{input +
+                                      src_displs[r] * src_pre * ncomp};
+                strided_device_copy(staging, field, width, src_post, width,
+                                    pitch);
+            } else {
+                std::size_t width{src_pre * src_counts[r] * sizeof(Complex)};
+                std::size_t pitch{src_pre * src_shape[src_axis] *
+                                  sizeof(Complex)};
+                std::size_t comp_block{src_pre * src_counts[r] * src_post};
+                for (std::size_t c{0}; c < ncomp; ++c) {
+                    const Complex * field{input + c * src_spatial +
+                                          src_displs[r] * src_pre};
+                    strided_device_copy(staging +
+                                            c * comp_block * sizeof(Complex),
+                                        field, width, src_post, width, pitch);
+                }
+            }
+        }
+#if defined(MUGRID_ENABLE_CUDA) || defined(MUGRID_ENABLE_HIP)
+        // Device-to-device 2D copies are asynchronous with respect to the
+        // host; MPI must not read the staging buffer before the gather is
+        // complete.
+        GPU_DEVICE_SYNCHRONIZE();
+#endif
+        // Pairwise ring exchange instead of MPI_Alltoallv: collective
+        // components are not reliably GPU-aware, while point-to-point on
+        // contiguous device buffers is the well-trodden CUDA/ROCm-aware
+        // path. At step s, rank r sends to r+s and receives from r-s; the
+        // partners match up at the same step on both sides, so the
+        // schedule is deadlock-free for any communicator size. (Sending
+        // to and receiving from the SAME peer each step deadlocks for
+        // size > 2: everyone would wait on a partner that sends to them
+        // only at a later step.)
+        {
+            MPI_Comm mpi_comm{this->comm.get_mpi_comm()};
+            int my_rank{this->comm.rank()};
+            for (int step{0}; step < comm_size; ++step) {
+                if (step == 0) {
+                    auto bytes{static_cast<std::size_t>(
+                                   send_counts_el[my_rank]) *
+                               sizeof(Complex)};
+                    if (bytes > 0) {
+                        strided_device_copy(
+                            recv_staging + static_cast<std::size_t>(
+                                               recv_displs_el[my_rank]) *
+                                               sizeof(Complex),
+                            send_staging + static_cast<std::size_t>(
+                                               send_displs_el[my_rank]) *
+                                               sizeof(Complex),
+                            bytes, 1, bytes, bytes);
+                    }
+                    continue;
+                }
+                int send_peer{(my_rank + step) % comm_size};
+                int recv_peer{(my_rank - step + comm_size) % comm_size};
+                MPI_Status status;
+                MPI_Sendrecv(send_staging +
+                                 static_cast<std::size_t>(
+                                     send_displs_el[send_peer]) *
+                                     sizeof(Complex),
+                             send_counts_el[send_peer], mpi_type<Complex>(),
+                             send_peer, 0,
+                             recv_staging +
+                                 static_cast<std::size_t>(
+                                     recv_displs_el[recv_peer]) *
+                                     sizeof(Complex),
+                             recv_counts_el[recv_peer], mpi_type<Complex>(),
+                             recv_peer, 0, mpi_comm, &status);
+            }
+        }
+
+        // Unpack: scatter each peer's block from the contiguous receive
+        // buffer into the output field. Runs on the default stream, so
+        // subsequent kernels are ordered after it.
+        for (int r{0}; r < comm_size; ++r) {
+            if (dst_counts[r] == 0) {
+                continue;
+            }
+            auto * staging{recv_staging +
+                           static_cast<std::size_t>(recv_displs_el[r]) *
+                               sizeof(Complex)};
+            if (aos) {
+                std::size_t width{dst_pre * dst_counts[r] * ncomp *
+                                  sizeof(Complex)};
+                std::size_t pitch{dst_pre * dst_shape[dst_axis] * ncomp *
+                                  sizeof(Complex)};
+                Complex * field{output + dst_displs[r] * dst_pre * ncomp};
+                strided_device_copy(field, staging, width, dst_post, pitch,
+                                    width);
+            } else {
+                std::size_t width{dst_pre * dst_counts[r] * sizeof(Complex)};
+                std::size_t pitch{dst_pre * dst_shape[dst_axis] *
+                                  sizeof(Complex)};
+                std::size_t comp_block{dst_pre * dst_counts[r] * dst_post};
+                for (std::size_t c{0}; c < ncomp; ++c) {
+                    Complex * field{output + c * dst_spatial +
+                                    dst_displs[r] * dst_pre};
+                    strided_device_copy(field,
+                                        staging +
+                                            c * comp_block * sizeof(Complex),
+                                        width, dst_post, pitch, width);
+                }
+            }
+        }
+    }
 #endif  // WITH_MPI
 
     void Transpose::forward(const Complex * input, Complex * output) const {
@@ -442,6 +677,17 @@ namespace muGrid {
             }
             total_size *= this->nb_components;
             std::copy(input, input + total_size, output);
+            return;
+        }
+
+        if (this->on_device) {
+            // Contiguous staging instead of derived datatypes on device
+            // pointers (see constructor documentation)
+            this->staged_alltoall(input, output, this->local_in,
+                                  this->axis_out, this->out_counts,
+                                  this->out_displs, this->local_out,
+                                  this->axis_in, this->in_counts,
+                                  this->in_displs);
             return;
         }
 
@@ -474,6 +720,17 @@ namespace muGrid {
             }
             total_size *= this->nb_components;
             std::copy(input, input + total_size, output);
+            return;
+        }
+
+        if (this->on_device) {
+            // Contiguous staging instead of derived datatypes on device
+            // pointers (see constructor documentation)
+            this->staged_alltoall(input, output, this->local_out,
+                                  this->axis_in, this->in_counts,
+                                  this->in_displs, this->local_in,
+                                  this->axis_out, this->out_counts,
+                                  this->out_displs);
             return;
         }
 

--- a/src/libmugrid/fft/transpose.cc
+++ b/src/libmugrid/fft/transpose.cc
@@ -38,6 +38,7 @@
 #include "core/exception.hh"
 #include "memory/device_alloc.hh"
 #include "memory/gpu_runtime.hh"
+#include "mpi/gpu_aware_mpi.hh"
 
 #include <algorithm>
 #include <numeric>
@@ -476,6 +477,25 @@ namespace muGrid {
         char * recv_staging{
             this->get_device_staging(1, recv_total * sizeof(Complex))};
 
+        // Without GPU-aware MPI, the flat exchange below operates on host
+        // bounce buffers instead of the device staging (correct with any
+        // MPI library); the pack/unpack stays on the device either way.
+        const bool bounce{!mpi_is_gpu_aware()};
+        char * send_buffer{send_staging};
+        char * recv_buffer{recv_staging};
+        if (bounce) {
+            auto & host_send{this->host_staging[0]};
+            auto & host_recv{this->host_staging[1]};
+            if (host_send.size() < send_total * sizeof(Complex)) {
+                host_send.resize(send_total * sizeof(Complex));
+            }
+            if (host_recv.size() < recv_total * sizeof(Complex)) {
+                host_recv.resize(recv_total * sizeof(Complex));
+            }
+            send_buffer = host_send.data();
+            recv_buffer = host_recv.data();
+        }
+
         // Pack: gather each peer's block into the contiguous send buffer
         for (int r{0}; r < comm_size; ++r) {
             if (src_counts[r] == 0) {
@@ -512,6 +532,10 @@ namespace muGrid {
         // host; MPI must not read the staging buffer before the gather is
         // complete.
         GPU_DEVICE_SYNCHRONIZE();
+        if (bounce && send_total > 0) {
+            GPU_MEMCPY_D2H(send_buffer, send_staging,
+                           send_total * sizeof(Complex));
+        }
 #endif
         // Pairwise ring exchange instead of MPI_Alltoallv: collective
         // components are not reliably GPU-aware, while point-to-point on
@@ -531,6 +555,7 @@ namespace muGrid {
                                    send_counts_el[my_rank]) *
                                sizeof(Complex)};
                     if (bytes > 0) {
+                        // The self block never leaves the device
                         strided_device_copy(
                             recv_staging + static_cast<std::size_t>(
                                                recv_displs_el[my_rank]) *
@@ -545,13 +570,13 @@ namespace muGrid {
                 int send_peer{(my_rank + step) % comm_size};
                 int recv_peer{(my_rank - step + comm_size) % comm_size};
                 MPI_Status status;
-                MPI_Sendrecv(send_staging +
+                MPI_Sendrecv(send_buffer +
                                  static_cast<std::size_t>(
                                      send_displs_el[send_peer]) *
                                      sizeof(Complex),
                              send_counts_el[send_peer], mpi_type<Complex>(),
                              send_peer, 0,
-                             recv_staging +
+                             recv_buffer +
                                  static_cast<std::size_t>(
                                      recv_displs_el[recv_peer]) *
                                      sizeof(Complex),
@@ -560,6 +585,29 @@ namespace muGrid {
             }
         }
 
+#if defined(MUGRID_ENABLE_CUDA) || defined(MUGRID_ENABLE_HIP)
+        if (bounce && recv_total > 0) {
+            // The self block (still on the device) occupies its slice of
+            // recv_staging; copying the bounced host data must not clobber
+            // it, so copy the two surrounding extents.
+            auto self_begin{static_cast<std::size_t>(
+                                recv_displs_el[this->comm.rank()]) *
+                            sizeof(Complex)};
+            auto self_end{self_begin +
+                          static_cast<std::size_t>(
+                              recv_counts_el[this->comm.rank()]) *
+                              sizeof(Complex)};
+            if (self_begin > 0) {
+                GPU_MEMCPY_H2D(recv_staging, recv_buffer, self_begin);
+            }
+            auto total_bytes{recv_total * sizeof(Complex)};
+            if (self_end < total_bytes) {
+                GPU_MEMCPY_H2D(recv_staging + self_end,
+                               recv_buffer + self_end,
+                               total_bytes - self_end);
+            }
+        }
+#endif
         // Unpack: scatter each peer's block from the contiguous receive
         // buffer into the output field. Runs on the default stream, so
         // subsequent kernels are ordered after it.

--- a/src/libmugrid/fft/transpose.cc
+++ b/src/libmugrid/fft/transpose.cc
@@ -396,6 +396,8 @@ namespace muGrid {
             GPU_MEMCPY_2D_D2D(dst, dst_pitch_bytes, src, src_pitch_bytes,
                               width_bytes, nb_rows);
 #else
+            // GCOVR_EXCL_START -- unreachable: device transposes require
+            // device fields, which cannot exist in a non-GPU build
             (void)dst;
             (void)src;
             (void)width_bytes;
@@ -403,6 +405,7 @@ namespace muGrid {
             (void)dst_pitch_bytes;
             (void)src_pitch_bytes;
             throw RuntimeError("Transpose: device data requires a GPU build");
+            // GCOVR_EXCL_STOP
 #endif
         }
     }  // namespace

--- a/src/libmugrid/fft/transpose.hh
+++ b/src/libmugrid/fft/transpose.hh
@@ -5,16 +5,18 @@
  *
  * @date   21 Dec 2024
  *
- * @brief  MPI transpose using derived datatypes (no explicit pack/unpack)
+ * @brief  MPI transpose: derived datatypes on host, contiguous staging on
+ *         device
  *
- * This implementation uses MPI derived datatypes (MPI_Type_create_subarray,
- * MPI_Type_vector, MPI_Type_create_hvector) with MPI_Alltoallw to perform
- * transpose operations without explicit pack/unpack buffers. This approach:
- *
- * - Eliminates memory overhead from temporary buffers
- * - Allows MPI to optimize non-contiguous memory access
- * - Works seamlessly with GPU-aware MPI implementations
- * - Supports multi-component fields (AoS and SoA layouts)
+ * Host transposes use MPI derived datatypes (MPI_Type_create_subarray,
+ * MPI_Type_create_hvector) with MPI_Alltoallw, avoiding explicit
+ * pack/unpack buffers and letting MPI optimize the non-contiguous access.
+ * Device transposes instead gather each peer's block into a contiguous
+ * staging buffer, exchange flat messages pairwise, and scatter on the
+ * receiver: MPI implementations pack strided datatypes on device memory
+ * block by block, which is orders of magnitude slower than a device-side
+ * gather. Both paths support multi-component fields (AoS and SoA layouts)
+ * and are wire-compatible with each other's block serialization.
  *
  * Copyright © 2024 Lars Pastewka
  *
@@ -61,11 +63,12 @@
 namespace muGrid {
 
     /**
-     * Handles MPI transpose operations using derived datatypes.
+     * Handles MPI transpose operations.
      *
-     * This class uses MPI derived datatypes instead of explicit pack/unpack
-     * buffers. The MPI library handles the non-contiguous memory access
-     * patterns, which can be more efficient and works with GPU-aware MPI.
+     * Host data is exchanged with MPI derived datatypes (no explicit
+     * pack/unpack; the MPI library handles the non-contiguous access).
+     * Device data is staged through cached contiguous device buffers (see
+     * the constructor's on_device parameter).
      *
      * For pencil decomposition, data needs to be redistributed between ranks to
      * switch which dimension is "local" (not distributed). The transpose
@@ -76,9 +79,7 @@ namespace muGrid {
      * The transpose is a genuine scatter-gather: every rank sends a disjoint
      * block to every peer and receives into a disjoint block of the output.
      * All send and receive buffers are non-overlapping, as required by the
-     * MPI standard for MPI_Alltoallw. Because only MPI intrinsics operate on
-     * the data buffers (no manual pack/unpack), the same code path works on
-     * device memory with a GPU-aware MPI implementation.
+     * MPI standard for MPI_Alltoallw.
      */
     class Transpose {
        public:
@@ -117,11 +118,13 @@ namespace muGrid {
 
         Transpose() = delete;
         Transpose(const Transpose & other) = delete;
-        Transpose(Transpose && other) noexcept;
+        // Transposes live behind unique_ptr in the engine's cache and are
+        // never moved or copied
+        Transpose(Transpose && other) = delete;
         ~Transpose();
 
         Transpose & operator=(const Transpose & other) = delete;
-        Transpose & operator=(Transpose && other) noexcept;
+        Transpose & operator=(Transpose && other) = delete;
 
         /**
          * Perform forward transpose (gather axis_in, scatter axis_out).

--- a/src/libmugrid/fft/transpose.hh
+++ b/src/libmugrid/fft/transpose.hh
@@ -307,6 +307,9 @@ namespace muGrid {
         mutable std::array<void *, 2> device_staging{{nullptr, nullptr}};
         //! Sizes of the staging buffers in bytes
         mutable std::array<std::size_t, 2> device_staging_size{{0, 0}};
+        //! Host bounce buffers (send, recv) used when the MPI library is
+        //! not GPU-aware (see mpi/gpu_aware_mpi.hh)
+        mutable std::array<std::vector<char>, 2> host_staging{};
     };
 
 }  // namespace muGrid

--- a/src/libmugrid/fft/transpose.hh
+++ b/src/libmugrid/fft/transpose.hh
@@ -50,6 +50,8 @@
 #include "core/coordinates.hh"
 #include "mpi/communicator.hh"
 
+#include <array>
+#include <cstddef>
 #include <vector>
 
 #ifdef WITH_MPI
@@ -97,12 +99,21 @@ namespace muGrid {
          * distributed)
          * @param nb_components  Number of field components (default: 1)
          * @param layout         Memory layout for multi-component fields
+         * @param on_device      True if the data pointers passed to
+         *                       forward()/backward() are device memory. Device
+         *                       transposes are staged through contiguous
+         *                       buffers instead of derived datatypes: MPI
+         *                       implementations pack strided datatypes on
+         *                       device memory block by block, which is orders
+         *                       of magnitude slower than a device-side gather
+         *                       followed by a contiguous all-to-all.
          */
         Transpose(const Communicator & comm, const DynGridIndex & local_in,
                   const DynGridIndex & local_out, Index_t global_in,
                   Index_t global_out, Index_t axis_in, Index_t axis_out,
                   Index_t nb_components = 1,
-                  StorageOrder layout = StorageOrder::ArrayOfStructures);
+                  StorageOrder layout = StorageOrder::ArrayOfStructures,
+                  bool on_device = false);
 
         Transpose() = delete;
         Transpose(const Transpose & other) = delete;
@@ -186,7 +197,29 @@ namespace muGrid {
          * Initialize datatypes for backward transpose.
          */
         void init_backward_types();
+
+        /**
+         * All-to-all through contiguous device staging buffers: gather each
+         * peer's subarray block of `input` into a flat send buffer
+         * (one strided 2D copy per block), MPI_Alltoallv, scatter the flat
+         * receive buffer into `output`. Block geometry: full extent in all
+         * dimensions except `src_axis`/`dst_axis`, where peer r owns
+         * `src_counts[r]` slices starting at `src_displs[r]`.
+         */
+        void staged_alltoall(const Complex * input, Complex * output,
+                             const DynGridIndex & src_shape, Index_t src_axis,
+                             const std::vector<Index_t> & src_counts,
+                             const std::vector<Index_t> & src_displs,
+                             const DynGridIndex & dst_shape, Index_t dst_axis,
+                             const std::vector<Index_t> & dst_counts,
+                             const std::vector<Index_t> & dst_displs) const;
+
+        //! Cached contiguous device staging buffer (slot 0: send, 1: recv)
+        char * get_device_staging(std::size_t slot, std::size_t size) const;
 #endif
+
+        //! Release the device staging buffers
+        void free_staging();
 
         /**
          * Compute how a dimension is distributed across ranks.
@@ -263,6 +296,14 @@ namespace muGrid {
 
         //! Flag indicating if datatypes have been initialized
         bool types_initialized{false};
+
+        //! True if forward()/backward() receive device pointers
+        bool on_device{false};
+
+        //! Contiguous device staging buffers (send, recv), grown on demand
+        mutable std::array<void *, 2> device_staging{{nullptr, nullptr}};
+        //! Sizes of the staging buffers in bytes
+        mutable std::array<std::size_t, 2> device_staging_size{{0, 0}};
     };
 
 }  // namespace muGrid

--- a/src/libmugrid/linalg/linalg.hh
+++ b/src/libmugrid/linalg/linalg.hh
@@ -177,21 +177,62 @@ T axpy_norm_sq(T alpha,
                TypedField<T, MemorySpace>& y);
 
 /**
- * Pointwise spectral scale: x[c, i] *= kernel[i] for every component c.
+ * Scale operation with per-pixel multiplier: x[c, i] *= alpha[c, i].
  *
- * Multiplies each component of a complex field elementwise by a
- * single-component real field on the same collection (e.g. the inverse
- * symbol of an operator in a Fourier-space preconditioner). Operates on
- * the FULL buffer; both fields must belong to the same (ghost-free
- * Fourier) collection.
+ * Overload of scal() where alpha generalizes from a scalar to a real
+ * field on the same collection. A single-component alpha is broadcast
+ * over the components of x (e.g. the inverse symbol of an operator in a
+ * Fourier-space preconditioner); an alpha with the same number of
+ * components as x is applied elementwise (e.g. a per-component Jacobi
+ * diagonal). Operates on the FULL buffer; entries of alpha in ghost
+ * pixels scale the corresponding ghost entries of x.
  *
  * @tparam MemorySpace Memory space (HostSpace, CUDASpace, ROCmSpace)
+ * @param alpha Real field of multipliers (1 or x's number of components)
  * @param x Complex input/output field (modified in place)
- * @param kernel Real single-component field of multipliers
  */
 template <typename MemorySpace>
-void pointwise_scale(TypedField<Complex, MemorySpace>& x,
-                     const TypedField<Real, MemorySpace>& kernel);
+void scal(const TypedField<Real, MemorySpace>& alpha,
+          TypedField<Complex, MemorySpace>& x);
+
+/**
+ * Scale operation with per-pixel multiplier: x[c, i] *= alpha[c, i].
+ *
+ * Real-field variant of the overload above, with the same broadcast
+ * rules; together with copy() this runs a Jacobi preconditioner
+ * entirely on the device.
+ *
+ * @tparam MemorySpace Memory space (HostSpace, CUDASpace, ROCmSpace)
+ * @param alpha Real field of multipliers (1 or x's number of components)
+ * @param x Real input/output field (modified in place)
+ */
+template <typename MemorySpace>
+void scal(const TypedField<Real, MemorySpace>& alpha,
+          TypedField<Real, MemorySpace>& x);
+
+namespace internal {
+
+    //! Validate a field-valued alpha for scal(): same collection, same
+    //! number of entries, and one or x's number of components
+    template <typename AlphaField, typename XField>
+    void check_field_alpha(const AlphaField& alpha, const XField& x) {
+        if (&x.get_collection() != &alpha.get_collection()) {
+            throw FieldError(
+                "scal: fields must belong to the same collection");
+        }
+        if (alpha.get_nb_entries() != x.get_nb_entries()) {
+            throw FieldError(
+                "scal: fields must have the same number of entries");
+        }
+        if (alpha.get_nb_components() != 1 &&
+            alpha.get_nb_components() != x.get_nb_components()) {
+            throw FieldError(
+                "scal: the field-valued alpha must have a single component "
+                "(broadcast) or the same number of components as x");
+        }
+    }
+
+}  // namespace internal
 
 }  // namespace linalg
 }  // namespace muGrid

--- a/src/libmugrid/linalg/linalg.hh
+++ b/src/libmugrid/linalg/linalg.hh
@@ -176,6 +176,23 @@ T axpy_norm_sq(T alpha,
                const TypedField<T, MemorySpace>& x,
                TypedField<T, MemorySpace>& y);
 
+/**
+ * Pointwise spectral scale: x[c, i] *= kernel[i] for every component c.
+ *
+ * Multiplies each component of a complex field elementwise by a
+ * single-component real field on the same collection (e.g. the inverse
+ * symbol of an operator in a Fourier-space preconditioner). Operates on
+ * the FULL buffer; both fields must belong to the same (ghost-free
+ * Fourier) collection.
+ *
+ * @tparam MemorySpace Memory space (HostSpace, CUDASpace, ROCmSpace)
+ * @param x Complex input/output field (modified in place)
+ * @param kernel Real single-component field of multipliers
+ */
+template <typename MemorySpace>
+void pointwise_scale(TypedField<Complex, MemorySpace>& x,
+                     const TypedField<Real, MemorySpace>& kernel);
+
 }  // namespace linalg
 }  // namespace muGrid
 

--- a/src/libmugrid/linalg/linalg_gpu.cc
+++ b/src/libmugrid/linalg/linalg_gpu.cc
@@ -304,17 +304,35 @@ __global__ void final_reduce_kernel(Real* data, Index_t n) {
     }
 }
 
-// Pointwise spectral scale: complex x scaled by real kernel, broadcast
-// over components. Operates on the doubles of the complex buffer to
-// avoid complex arithmetic in device code.
-__global__ void pointwise_scale_kernel(Real* x2, const Real* k,
-                                       Index_t npix, Index_t ncomp,
-                                       bool soa, Index_t n2) {
+// Scale complex x by a real per-pixel field alpha; alpha is either
+// broadcast over the components of x (alpha_per_comp == false) or
+// applied elementwise (alpha has x's components). Operates on the
+// doubles of the complex buffer to avoid complex arithmetic in device
+// code.
+__global__ void field_scal_complex_kernel(Real* x2, const Real* a,
+                                          Index_t npix, Index_t ncomp,
+                                          bool soa, bool alpha_per_comp,
+                                          Index_t n2) {
     Index_t j = blockIdx.x * blockDim.x + threadIdx.x;
     if (j < n2) {
-        Index_t pair = j >> 1;  // complex element index
-        Index_t i = soa ? (pair % npix) : (pair / ncomp);
-        x2[j] *= k[i];
+        Index_t elem = j >> 1;  // complex element index
+        Index_t i = alpha_per_comp
+                        ? elem
+                        : (soa ? (elem % npix) : (elem / ncomp));
+        x2[j] *= a[i];
+    }
+}
+
+// Real variant of the kernel above
+__global__ void field_scal_real_kernel(Real* x, const Real* a,
+                                       Index_t npix, Index_t ncomp,
+                                       bool soa, bool alpha_per_comp,
+                                       Index_t n) {
+    Index_t j = blockIdx.x * blockDim.x + threadIdx.x;
+    if (j < n) {
+        Index_t i =
+            alpha_per_comp ? j : (soa ? (j % npix) : (j / ncomp));
+        x[j] *= a[i];
     }
 }
 
@@ -629,33 +647,48 @@ Real axpy_norm_sq<Real, DeviceSpace>(Real alpha,
 
 /* ---------------------------------------------------------------------- */
 template <>
-void pointwise_scale<DeviceSpace>(TypedField<Complex, DeviceSpace>& x,
-                                  const TypedField<Real, DeviceSpace>& kernel) {
-    if (&x.get_collection() != &kernel.get_collection()) {
-        throw FieldError(
-            "pointwise_scale: fields must belong to the same collection");
-    }
-    if (kernel.get_nb_components() != 1) {
-        throw FieldError(
-            "pointwise_scale: kernel must have a single component");
-    }
-    if (kernel.get_nb_entries() != x.get_nb_entries()) {
-        throw FieldError(
-            "pointwise_scale: fields must have the same number of entries");
-    }
+void scal<DeviceSpace>(const TypedField<Real, DeviceSpace>& alpha,
+                       TypedField<Complex, DeviceSpace>& x) {
+    internal::check_field_alpha(alpha, x);
 
     const Index_t npix = x.get_nb_entries();
     const Index_t ncomp = x.get_nb_components();
     const Index_t n2 = npix * ncomp * 2;
     const bool soa =
         (x.get_storage_order() == StorageOrder::StructureOfArrays);
+    const bool alpha_per_comp = (alpha.get_nb_components() == ncomp &&
+                                 ncomp != 1);
     const int num_blocks = (n2 + gpu_kernels::BLOCK_SIZE - 1) /
                            gpu_kernels::BLOCK_SIZE;
 
-    GPU_LAUNCH_KERNEL(gpu_kernels::pointwise_scale_kernel,
+    GPU_LAUNCH_KERNEL(gpu_kernels::field_scal_complex_kernel,
                       num_blocks, gpu_kernels::BLOCK_SIZE,
                       reinterpret_cast<Real*>(x.view().data()),
-                      kernel.view().data(), npix, ncomp, soa, n2);
+                      alpha.view().data(), npix, ncomp, soa,
+                      alpha_per_comp, n2);
+    GPU_DEVICE_SYNCHRONIZE();
+}
+
+/* ---------------------------------------------------------------------- */
+template <>
+void scal<DeviceSpace>(const TypedField<Real, DeviceSpace>& alpha,
+                       TypedField<Real, DeviceSpace>& x) {
+    internal::check_field_alpha(alpha, x);
+
+    const Index_t npix = x.get_nb_entries();
+    const Index_t ncomp = x.get_nb_components();
+    const Index_t n = npix * ncomp;
+    const bool soa =
+        (x.get_storage_order() == StorageOrder::StructureOfArrays);
+    const bool alpha_per_comp = (alpha.get_nb_components() == ncomp &&
+                                 ncomp != 1);
+    const int num_blocks = (n + gpu_kernels::BLOCK_SIZE - 1) /
+                           gpu_kernels::BLOCK_SIZE;
+
+    GPU_LAUNCH_KERNEL(gpu_kernels::field_scal_real_kernel,
+                      num_blocks, gpu_kernels::BLOCK_SIZE,
+                      x.view().data(), alpha.view().data(), npix, ncomp,
+                      soa, alpha_per_comp, n);
     GPU_DEVICE_SYNCHRONIZE();
 }
 

--- a/src/libmugrid/linalg/linalg_gpu.cc
+++ b/src/libmugrid/linalg/linalg_gpu.cc
@@ -42,28 +42,11 @@
 #include "collection/field_collection_global.hh"
 #include "core/exception.hh"
 
-// Unified GPU abstraction macros
+#include "memory/gpu_runtime.hh"
+
 #if defined(MUGRID_ENABLE_CUDA)
-    #include <cuda_runtime.h>
-    #define GPU_LAUNCH_KERNEL(kernel, grid, block, ...) \
-        kernel<<<grid, block>>>(__VA_ARGS__)
-    #define GPU_DEVICE_SYNCHRONIZE() (void)cudaDeviceSynchronize()
-    #define GPU_MALLOC(ptr, size) (void)cudaMalloc(ptr, size)
-    #define GPU_FREE(ptr) (void)cudaFree(ptr)
-    #define GPU_MEMCPY_D2H(dst, src, size) \
-        (void)cudaMemcpy(dst, src, size, cudaMemcpyDeviceToHost)
-    #define GPU_MEMSET(ptr, value, size) (void)cudaMemset(ptr, value, size)
     using DeviceSpace = muGrid::CUDASpace;
 #elif defined(MUGRID_ENABLE_HIP)
-    #include <hip/hip_runtime.h>
-    #define GPU_LAUNCH_KERNEL(kernel, grid, block, ...) \
-        hipLaunchKernelGGL(kernel, grid, block, 0, 0, __VA_ARGS__)
-    #define GPU_DEVICE_SYNCHRONIZE() (void)hipDeviceSynchronize()
-    #define GPU_MALLOC(ptr, size) (void)hipMalloc(ptr, size)
-    #define GPU_FREE(ptr) (void)hipFree(ptr)
-    #define GPU_MEMCPY_D2H(dst, src, size) \
-        (void)hipMemcpy(dst, src, size, hipMemcpyDeviceToHost)
-    #define GPU_MEMSET(ptr, value, size) (void)hipMemset(ptr, value, size)
     using DeviceSpace = muGrid::ROCmSpace;
 #endif
 
@@ -318,6 +301,20 @@ __global__ void final_reduce_kernel(Real* data, Index_t n) {
     // Write final result
     if (tid == 0) {
         data[0] = shared_data[0];
+    }
+}
+
+// Pointwise spectral scale: complex x scaled by real kernel, broadcast
+// over components. Operates on the doubles of the complex buffer to
+// avoid complex arithmetic in device code.
+__global__ void pointwise_scale_kernel(Real* x2, const Real* k,
+                                       Index_t npix, Index_t ncomp,
+                                       bool soa, Index_t n2) {
+    Index_t j = blockIdx.x * blockDim.x + threadIdx.x;
+    if (j < n2) {
+        Index_t pair = j >> 1;  // complex element index
+        Index_t i = soa ? (pair % npix) : (pair / ncomp);
+        x2[j] *= k[i];
     }
 }
 
@@ -628,6 +625,38 @@ Real axpy_norm_sq<Real, DeviceSpace>(Real alpha,
     GPU_MEMCPY_D2H(&result, d_partial, sizeof(Real));
     GPU_FREE(d_partial);
     return result;
+}
+
+/* ---------------------------------------------------------------------- */
+template <>
+void pointwise_scale<DeviceSpace>(TypedField<Complex, DeviceSpace>& x,
+                                  const TypedField<Real, DeviceSpace>& kernel) {
+    if (&x.get_collection() != &kernel.get_collection()) {
+        throw FieldError(
+            "pointwise_scale: fields must belong to the same collection");
+    }
+    if (kernel.get_nb_components() != 1) {
+        throw FieldError(
+            "pointwise_scale: kernel must have a single component");
+    }
+    if (kernel.get_nb_entries() != x.get_nb_entries()) {
+        throw FieldError(
+            "pointwise_scale: fields must have the same number of entries");
+    }
+
+    const Index_t npix = x.get_nb_entries();
+    const Index_t ncomp = x.get_nb_components();
+    const Index_t n2 = npix * ncomp * 2;
+    const bool soa =
+        (x.get_storage_order() == StorageOrder::StructureOfArrays);
+    const int num_blocks = (n2 + gpu_kernels::BLOCK_SIZE - 1) /
+                           gpu_kernels::BLOCK_SIZE;
+
+    GPU_LAUNCH_KERNEL(gpu_kernels::pointwise_scale_kernel,
+                      num_blocks, gpu_kernels::BLOCK_SIZE,
+                      reinterpret_cast<Real*>(x.view().data()),
+                      kernel.view().data(), npix, ncomp, soa, n2);
+    GPU_DEVICE_SYNCHRONIZE();
 }
 
 // Complex versions would follow the same pattern but with Complex type

--- a/src/libmugrid/linalg/linalg_host.cc
+++ b/src/libmugrid/linalg/linalg_host.cc
@@ -424,5 +424,43 @@ Complex axpy_norm_sq<Complex, HostSpace>(Complex alpha,
     return y.eigen_vec().squaredNorm();
 }
 
+/* ---------------------------------------------------------------------- */
+template <>
+void pointwise_scale<HostSpace>(TypedField<Complex, HostSpace>& x,
+                                const TypedField<Real, HostSpace>& kernel) {
+    if (&x.get_collection() != &kernel.get_collection()) {
+        throw FieldError(
+            "pointwise_scale: fields must belong to the same collection");
+    }
+    if (kernel.get_nb_components() != 1) {
+        throw FieldError(
+            "pointwise_scale: kernel must have a single component");
+    }
+    if (kernel.get_nb_entries() != x.get_nb_entries()) {
+        throw FieldError(
+            "pointwise_scale: fields must have the same number of entries");
+    }
+
+    const Index_t npix = x.get_nb_entries();
+    const Index_t ncomp = x.get_nb_components();
+    Complex* xd = x.view().data();
+    const Real* kd = kernel.view().data();
+
+    if (x.get_storage_order() == StorageOrder::StructureOfArrays) {
+        for (Index_t c{0}; c < ncomp; ++c) {
+            Complex* xc = xd + c * npix;
+            for (Index_t i{0}; i < npix; ++i) {
+                xc[i] *= kd[i];
+            }
+        }
+    } else {
+        for (Index_t i{0}; i < npix; ++i) {
+            for (Index_t c{0}; c < ncomp; ++c) {
+                xd[i * ncomp + c] *= kd[i];
+            }
+        }
+    }
+}
+
 }  // namespace linalg
 }  // namespace muGrid

--- a/src/libmugrid/linalg/linalg_host.cc
+++ b/src/libmugrid/linalg/linalg_host.cc
@@ -426,37 +426,63 @@ Complex axpy_norm_sq<Complex, HostSpace>(Complex alpha,
 
 /* ---------------------------------------------------------------------- */
 template <>
-void pointwise_scale<HostSpace>(TypedField<Complex, HostSpace>& x,
-                                const TypedField<Real, HostSpace>& kernel) {
-    if (&x.get_collection() != &kernel.get_collection()) {
-        throw FieldError(
-            "pointwise_scale: fields must belong to the same collection");
-    }
-    if (kernel.get_nb_components() != 1) {
-        throw FieldError(
-            "pointwise_scale: kernel must have a single component");
-    }
-    if (kernel.get_nb_entries() != x.get_nb_entries()) {
-        throw FieldError(
-            "pointwise_scale: fields must have the same number of entries");
-    }
+void scal<HostSpace>(const TypedField<Real, HostSpace>& alpha,
+                     TypedField<Complex, HostSpace>& x) {
+    internal::check_field_alpha(alpha, x);
 
     const Index_t npix = x.get_nb_entries();
     const Index_t ncomp = x.get_nb_components();
     Complex* xd = x.view().data();
-    const Real* kd = kernel.view().data();
+    const Real* ad = alpha.view().data();
 
-    if (x.get_storage_order() == StorageOrder::StructureOfArrays) {
+    if (alpha.get_nb_components() == ncomp) {
+        // Elementwise: alpha and x share the same buffer layout
+        for (Index_t i{0}; i < npix * ncomp; ++i) {
+            xd[i] *= ad[i];
+        }
+    } else if (x.get_storage_order() == StorageOrder::StructureOfArrays) {
         for (Index_t c{0}; c < ncomp; ++c) {
             Complex* xc = xd + c * npix;
             for (Index_t i{0}; i < npix; ++i) {
-                xc[i] *= kd[i];
+                xc[i] *= ad[i];
             }
         }
     } else {
         for (Index_t i{0}; i < npix; ++i) {
             for (Index_t c{0}; c < ncomp; ++c) {
-                xd[i * ncomp + c] *= kd[i];
+                xd[i * ncomp + c] *= ad[i];
+            }
+        }
+    }
+}
+
+/* ---------------------------------------------------------------------- */
+template <>
+void scal<HostSpace>(const TypedField<Real, HostSpace>& alpha,
+                     TypedField<Real, HostSpace>& x) {
+    internal::check_field_alpha(alpha, x);
+
+    const Index_t npix = x.get_nb_entries();
+    const Index_t ncomp = x.get_nb_components();
+    Real* xd = x.view().data();
+    const Real* ad = alpha.view().data();
+
+    if (alpha.get_nb_components() == ncomp) {
+        // Elementwise: alpha and x share the same buffer layout
+        for (Index_t i{0}; i < npix * ncomp; ++i) {
+            xd[i] *= ad[i];
+        }
+    } else if (x.get_storage_order() == StorageOrder::StructureOfArrays) {
+        for (Index_t c{0}; c < ncomp; ++c) {
+            Real* xc = xd + c * npix;
+            for (Index_t i{0}; i < npix; ++i) {
+                xc[i] *= ad[i];
+            }
+        }
+    } else {
+        for (Index_t i{0}; i < npix; ++i) {
+            for (Index_t c{0}; c < ncomp; ++c) {
+                xd[i * ncomp + c] *= ad[i];
             }
         }
     }

--- a/src/libmugrid/memory/array.hh
+++ b/src/libmugrid/memory/array.hh
@@ -42,6 +42,7 @@
 #include <string>
 #include <stdexcept>
 
+#include "device_alloc.hh"
 #include "memory_space.hh"
 
 #if defined(MUGRID_ENABLE_CUDA)
@@ -84,22 +85,18 @@ namespace muGrid {
          */
         template <typename T>
         struct CudaAllocator {
+            // Allocation goes through device_allocate() so that an
+            // externally registered allocator (e.g. cupy's memory pool)
+            // owns every device byte; see memory/device_alloc.hh.
             static T * allocate(std::size_t n) {
                 if (n == 0)
                     return nullptr;
-                T * ptr = nullptr;
-                cudaError_t err = cudaMalloc(&ptr, n * sizeof(T));
-                if (err != cudaSuccess) {
-                    throw std::runtime_error(
-                        std::string("CUDA allocation failed: ") +
-                        cudaGetErrorString(err));
-                }
-                return ptr;
+                return static_cast<T *>(device_allocate(n * sizeof(T)));
             }
 
             static void deallocate(T * ptr) {
                 if (ptr)
-                    (void)cudaFree(ptr);
+                    device_deallocate(ptr);
             }
 
             static void memset(T * ptr, int value, std::size_t n) {
@@ -115,22 +112,18 @@ namespace muGrid {
          */
         template <typename T>
         struct HIPAllocator {
+            // Allocation goes through device_allocate() so that an
+            // externally registered allocator (e.g. cupy's memory pool)
+            // owns every device byte; see memory/device_alloc.hh.
             static T * allocate(std::size_t n) {
                 if (n == 0)
                     return nullptr;
-                T * ptr = nullptr;
-                hipError_t err = hipMalloc(&ptr, n * sizeof(T));
-                if (err != hipSuccess) {
-                    throw std::runtime_error(
-                        std::string("HIP allocation failed: ") +
-                        hipGetErrorString(err));
-                }
-                return ptr;
+                return static_cast<T *>(device_allocate(n * sizeof(T)));
             }
 
             static void deallocate(T * ptr) {
                 if (ptr)
-                    (void)hipFree(ptr);
+                    device_deallocate(ptr);
             }
 
             static void memset(T * ptr, int value, std::size_t n) {

--- a/src/libmugrid/memory/device_alloc.cc
+++ b/src/libmugrid/memory/device_alloc.cc
@@ -73,12 +73,6 @@ namespace muGrid {
         state.deallocate = deallocate;
     }
 
-    bool has_external_device_allocator() {
-        auto & state{allocator_state()};
-        std::lock_guard<std::mutex> lock{state.mutex};
-        return state.allocate != nullptr;
-    }
-
     void * device_allocate(std::size_t bytes) {
         if (bytes == 0) {
             return nullptr;
@@ -114,8 +108,11 @@ namespace muGrid {
         }
         return ptr;
 #else
+        // GCOVR_EXCL_START -- unreachable: device fields cannot be created
+        // in a build without a GPU backend
         throw RuntimeError(
             "device_allocate: muGrid was compiled without GPU support");
+        // GCOVR_EXCL_STOP
 #endif
     }
 

--- a/src/libmugrid/memory/device_alloc.cc
+++ b/src/libmugrid/memory/device_alloc.cc
@@ -1,0 +1,148 @@
+/**
+ * @file   memory/device_alloc.cc
+ *
+ * @author Lars Pastewka <lars.pastewka@imtek.uni-freiburg.de>
+ *
+ * @date   12 Jun 2026
+ *
+ * @brief  Runtime device memory allocation with a pluggable allocator hook
+ *
+ * Copyright © 2026 Lars Pastewka
+ *
+ * µGrid is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3, or (at
+ * your option) any later version.
+ *
+ * µGrid is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with µGrid; see the file COPYING. If not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ * Additional permission under GNU GPL version 3 section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with proprietary FFT implementations or numerical libraries, containing parts
+ * covered by the terms of those libraries' licenses, the licensors of this
+ * Program grant you additional permission to convey the resulting work.
+ */
+
+#include "memory/device_alloc.hh"
+
+#include <mutex>
+#include <string>
+#include <unordered_set>
+
+#include "core/exception.hh"
+#include "memory/gpu_runtime.hh"
+
+namespace muGrid {
+
+    namespace {
+        struct DeviceAllocatorState {
+            DeviceAllocateFn allocate{nullptr};
+            DeviceDeallocateFn deallocate{nullptr};
+            // Pointers produced by the external allocator. A pointer must be
+            // freed by the allocator that produced it, even if the hook was
+            // switched in between.
+            std::unordered_set<void *> external_ptrs{};
+            std::mutex mutex{};
+        };
+
+        DeviceAllocatorState & allocator_state() {
+            static DeviceAllocatorState state{};
+            return state;
+        }
+    }  // namespace
+
+    void set_device_allocator(DeviceAllocateFn allocate,
+                              DeviceDeallocateFn deallocate) {
+        if ((allocate == nullptr) != (deallocate == nullptr)) {
+            throw RuntimeError(
+                "set_device_allocator: allocate and deallocate must both be "
+                "set or both be null");
+        }
+        auto & state{allocator_state()};
+        std::lock_guard<std::mutex> lock{state.mutex};
+        state.allocate = allocate;
+        state.deallocate = deallocate;
+    }
+
+    bool has_external_device_allocator() {
+        auto & state{allocator_state()};
+        std::lock_guard<std::mutex> lock{state.mutex};
+        return state.allocate != nullptr;
+    }
+
+    void * device_allocate(std::size_t bytes) {
+        if (bytes == 0) {
+            return nullptr;
+        }
+        auto & state{allocator_state()};
+        {
+            std::lock_guard<std::mutex> lock{state.mutex};
+            if (state.allocate != nullptr) {
+                void * ptr{state.allocate(bytes)};
+                if (ptr == nullptr) {
+                    throw RuntimeError(
+                        "External device allocator failed to allocate " +
+                        std::to_string(bytes) + " bytes");
+                }
+                state.external_ptrs.insert(ptr);
+                return ptr;
+            }
+        }
+#if defined(MUGRID_ENABLE_CUDA)
+        void * ptr{nullptr};
+        cudaError_t err{cudaMalloc(&ptr, bytes)};
+        if (err != cudaSuccess) {
+            throw RuntimeError(std::string("CUDA allocation failed: ") +
+                               cudaGetErrorString(err));
+        }
+        return ptr;
+#elif defined(MUGRID_ENABLE_HIP)
+        void * ptr{nullptr};
+        hipError_t err{hipMalloc(&ptr, bytes)};
+        if (err != hipSuccess) {
+            throw RuntimeError(std::string("HIP allocation failed: ") +
+                               hipGetErrorString(err));
+        }
+        return ptr;
+#else
+        throw RuntimeError(
+            "device_allocate: muGrid was compiled without GPU support");
+#endif
+    }
+
+    void device_deallocate(void * ptr) {
+        if (ptr == nullptr) {
+            return;
+        }
+        auto & state{allocator_state()};
+        {
+            std::lock_guard<std::mutex> lock{state.mutex};
+            auto it{state.external_ptrs.find(ptr)};
+            if (it != state.external_ptrs.end()) {
+                state.external_ptrs.erase(it);
+                if (state.deallocate != nullptr) {
+                    state.deallocate(ptr);
+                }
+                // If the external allocator was unregistered while its
+                // allocations were alive there is nothing safe to do; the
+                // pointer is intentionally leaked (documented contract).
+                return;
+            }
+        }
+#if defined(MUGRID_ENABLE_CUDA)
+        (void)cudaFree(ptr);
+#elif defined(MUGRID_ENABLE_HIP)
+        (void)hipFree(ptr);
+#endif
+    }
+
+}  // namespace muGrid

--- a/src/libmugrid/memory/device_alloc.hh
+++ b/src/libmugrid/memory/device_alloc.hh
@@ -65,9 +65,6 @@ namespace muGrid {
     void set_device_allocator(DeviceAllocateFn allocate,
                               DeviceDeallocateFn deallocate);
 
-    //! True if an external device allocator is registered.
-    bool has_external_device_allocator();
-
     /**
      * Allocate `bytes` bytes of device memory through the registered
      * allocator (or raw cudaMalloc/hipMalloc by default). Throws

--- a/src/libmugrid/memory/device_alloc.hh
+++ b/src/libmugrid/memory/device_alloc.hh
@@ -1,0 +1,83 @@
+/**
+ * @file   memory/device_alloc.hh
+ *
+ * @author Lars Pastewka <lars.pastewka@imtek.uni-freiburg.de>
+ *
+ * @date   12 Jun 2026
+ *
+ * @brief  Runtime device memory allocation with a pluggable allocator hook
+ *
+ * Unlike the compile-time-typed Array<T, MemorySpace>, these functions
+ * allocate device memory based on a runtime decision (e.g. a field's
+ * is_on_device flag). All device allocations in muGrid should go through
+ * this interface (directly or via the Array allocators) so that an
+ * externally registered allocator — e.g. cupy's memory pool when muGrid
+ * is driven from Python — owns every device byte. Two independent
+ * allocators on one device starve each other: a caching pool never
+ * returns freed blocks to the driver, so raw cudaMalloc/hipMalloc in the
+ * other allocator fails even though memory is "free".
+ *
+ * Copyright © 2026 Lars Pastewka
+ *
+ * µGrid is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3, or (at
+ * your option) any later version.
+ *
+ * µGrid is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with µGrid; see the file COPYING. If not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ * Additional permission under GNU GPL version 3 section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with proprietary FFT implementations or numerical libraries, containing parts
+ * covered by the terms of those libraries' licenses, the licensors of this
+ * Program grant you additional permission to convey the resulting work.
+ */
+
+#ifndef SRC_LIBMUGRID_MEMORY_DEVICE_ALLOC_HH_
+#define SRC_LIBMUGRID_MEMORY_DEVICE_ALLOC_HH_
+
+#include <cstddef>
+
+namespace muGrid {
+
+    //! Signature of an external device allocator: returns a device pointer
+    //! to at least `bytes` bytes, or nullptr on failure.
+    using DeviceAllocateFn = void * (*)(std::size_t bytes);
+    //! Signature of the matching deallocator.
+    using DeviceDeallocateFn = void (*)(void * ptr);
+
+    /**
+     * Register an external device allocator (e.g. one drawing from cupy's
+     * memory pool). Pass nullptrs to restore the default backend
+     * allocator. Pointers allocated before the switch are freed through
+     * the allocator that produced them; do not unregister while such
+     * allocations are alive unless the external allocator outlives them.
+     */
+    void set_device_allocator(DeviceAllocateFn allocate,
+                              DeviceDeallocateFn deallocate);
+
+    //! True if an external device allocator is registered.
+    bool has_external_device_allocator();
+
+    /**
+     * Allocate `bytes` bytes of device memory through the registered
+     * allocator (or raw cudaMalloc/hipMalloc by default). Throws
+     * RuntimeError on failure or when no GPU backend is compiled in.
+     */
+    void * device_allocate(std::size_t bytes);
+
+    //! Free memory obtained from device_allocate().
+    void device_deallocate(void * ptr);
+
+}  // namespace muGrid
+
+#endif  // SRC_LIBMUGRID_MEMORY_DEVICE_ALLOC_HH_

--- a/src/libmugrid/memory/gpu_runtime.hh
+++ b/src/libmugrid/memory/gpu_runtime.hh
@@ -1,0 +1,121 @@
+/**
+ * @file   memory/gpu_runtime.hh
+ *
+ * @author Lars Pastewka <lars.pastewka@imtek.uni-freiburg.de>
+ *
+ * @date   12 Jun 2026
+ *
+ * @brief  Single shared CUDA/HIP portability shim
+ *
+ * All GPU sources include this header instead of defining their own
+ * backend macros. The rule: backend-specific blocks may differ only in
+ * API spelling; no control flow or arithmetic lives inside the #ifdef
+ * branches. Kernels themselves are single-source `__global__` functions.
+ *
+ * Copyright © 2026 Lars Pastewka
+ *
+ * µGrid is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3, or (at
+ * your option) any later version.
+ *
+ * µGrid is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with µGrid; see the file COPYING. If not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ * Additional permission under GNU GPL version 3 section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with proprietary FFT implementations or numerical libraries, containing parts
+ * covered by the terms of those libraries' licenses, the licensors of this
+ * Program grant you additional permission to convey the resulting work.
+ */
+
+#ifndef SRC_LIBMUGRID_MEMORY_GPU_RUNTIME_HH_
+#define SRC_LIBMUGRID_MEMORY_GPU_RUNTIME_HH_
+
+#if defined(MUGRID_ENABLE_CUDA)
+
+#include <cuda_runtime.h>
+
+using gpuStream_t = cudaStream_t;
+
+// Kernel launches (only valid in CUDA/HIP translation units)
+#define GPU_LAUNCH_KERNEL(kernel, grid, block, ...) \
+    kernel<<<grid, block>>>(__VA_ARGS__)
+#define GPU_LAUNCH_KERNEL_SHMEM(kernel, grid, block, shmem, ...) \
+    kernel<<<grid, block, shmem>>>(__VA_ARGS__)
+#define GPU_LAUNCH_KERNEL_STREAM(kernel, grid, block, stream, ...) \
+    kernel<<<grid, block, 0, stream>>>(__VA_ARGS__)
+
+// Host-callable runtime API (valid in any translation unit)
+#define GPU_DEVICE_SYNCHRONIZE() (void)cudaDeviceSynchronize()
+#define GPU_MALLOC(ptr, size) (void)cudaMalloc(ptr, size)
+#define GPU_FREE(ptr) (void)cudaFree(ptr)
+#define GPU_MEMSET(ptr, value, size) (void)cudaMemset(ptr, value, size)
+#define GPU_MEMCPY_D2H(dst, src, size) \
+    (void)cudaMemcpy(dst, src, size, cudaMemcpyDeviceToHost)
+#define GPU_MEMCPY_H2D(dst, src, size) \
+    (void)cudaMemcpy(dst, src, size, cudaMemcpyHostToDevice)
+#define GPU_MEMCPY_D2D(dst, src, size) \
+    (void)cudaMemcpy(dst, src, size, cudaMemcpyDeviceToDevice)
+#define GPU_MEMCPY_2D_D2D(dst, dpitch, src, spitch, width, height) \
+    (void)cudaMemcpy2D(dst, dpitch, src, spitch, width, height, \
+                       cudaMemcpyDeviceToDevice)
+#define GPU_MEMCPY_TO_SYMBOL(symbol, src, size) \
+    (void)cudaMemcpyToSymbol(symbol, src, size)
+
+namespace muGrid {
+    //! nullptr if the last GPU runtime call succeeded, else the error string
+    inline const char * gpu_last_error() {
+        cudaError_t err{cudaGetLastError()};
+        return err == cudaSuccess ? nullptr : cudaGetErrorString(err);
+    }
+}  // namespace muGrid
+
+#elif defined(MUGRID_ENABLE_HIP)
+
+#include <hip/hip_runtime.h>
+
+using gpuStream_t = hipStream_t;
+
+#define GPU_LAUNCH_KERNEL(kernel, grid, block, ...) \
+    hipLaunchKernelGGL(kernel, grid, block, 0, 0, __VA_ARGS__)
+#define GPU_LAUNCH_KERNEL_SHMEM(kernel, grid, block, shmem, ...) \
+    hipLaunchKernelGGL(kernel, grid, block, shmem, 0, __VA_ARGS__)
+#define GPU_LAUNCH_KERNEL_STREAM(kernel, grid, block, stream, ...) \
+    hipLaunchKernelGGL(kernel, grid, block, 0, stream, __VA_ARGS__)
+
+#define GPU_DEVICE_SYNCHRONIZE() (void)hipDeviceSynchronize()
+#define GPU_MALLOC(ptr, size) (void)hipMalloc(ptr, size)
+#define GPU_FREE(ptr) (void)hipFree(ptr)
+#define GPU_MEMSET(ptr, value, size) (void)hipMemset(ptr, value, size)
+#define GPU_MEMCPY_D2H(dst, src, size) \
+    (void)hipMemcpy(dst, src, size, hipMemcpyDeviceToHost)
+#define GPU_MEMCPY_H2D(dst, src, size) \
+    (void)hipMemcpy(dst, src, size, hipMemcpyHostToDevice)
+#define GPU_MEMCPY_D2D(dst, src, size) \
+    (void)hipMemcpy(dst, src, size, hipMemcpyDeviceToDevice)
+#define GPU_MEMCPY_2D_D2D(dst, dpitch, src, spitch, width, height) \
+    (void)hipMemcpy2D(dst, dpitch, src, spitch, width, height, \
+                      hipMemcpyDeviceToDevice)
+#define GPU_MEMCPY_TO_SYMBOL(symbol, src, size) \
+    (void)hipMemcpyToSymbol(symbol, src, size)
+
+namespace muGrid {
+    //! nullptr if the last GPU runtime call succeeded, else the error string
+    inline const char * gpu_last_error() {
+        hipError_t err{hipGetLastError()};
+        return err == hipSuccess ? nullptr : hipGetErrorString(err);
+    }
+}  // namespace muGrid
+
+#endif  // MUGRID_ENABLE_CUDA / MUGRID_ENABLE_HIP
+
+#endif  // SRC_LIBMUGRID_MEMORY_GPU_RUNTIME_HH_

--- a/src/libmugrid/mpi/cartesian_communicator.cc
+++ b/src/libmugrid/mpi/cartesian_communicator.cc
@@ -15,6 +15,7 @@
 
 #include "memory/device_alloc.hh"
 #include "memory/gpu_runtime.hh"
+#include "mpi/gpu_aware_mpi.hh"
 
 namespace muGrid {
 
@@ -366,11 +367,38 @@ namespace muGrid {
         // completed.
         GPU_DEVICE_SYNCHRONIZE();
 #endif
+        // Without GPU-aware MPI, bounce the contiguous staging buffers
+        // through host memory (correct with any MPI library).
+        const bool bounce{!mpi_is_gpu_aware()};
+        char * send_buffer{send_staging};
+        char * recv_buffer{recv_staging};
+        if (bounce) {
+#if defined(MUGRID_ENABLE_CUDA) || defined(MUGRID_ENABLE_HIP)
+            auto & host_send{this->host_staging[0]};
+            auto & host_recv{this->host_staging[1]};
+            if (host_send.size() < send_bytes) {
+                host_send.resize(send_bytes);
+            }
+            if (host_recv.size() < recv_bytes) {
+                host_recv.resize(recv_bytes);
+            }
+            if (send_bytes > 0) {
+                GPU_MEMCPY_D2H(host_send.data(), send_staging, send_bytes);
+            }
+            send_buffer = host_send.data();
+            recv_buffer = host_recv.data();
+#endif
+        }
         MPI_Status status;
-        MPI_Sendrecv(send_staging, nb_send_blocks * send_block_len,
-                     mpi_datatype, dest_rank, 0, recv_staging,
+        MPI_Sendrecv(send_buffer, nb_send_blocks * send_block_len,
+                     mpi_datatype, dest_rank, 0, recv_buffer,
                      nb_recv_blocks * recv_block_len, mpi_datatype, src_rank, 0,
                      this->comm, &status);
+        if (bounce && recv_bytes > 0) {
+#if defined(MUGRID_ENABLE_CUDA) || defined(MUGRID_ENABLE_HIP)
+            GPU_MEMCPY_H2D(recv_staging, recv_buffer, recv_bytes);
+#endif
+        }
         if (recv_bytes > 0) {
             // Scatter the contiguous receive buffer into the strided halo.
             // This runs on the default stream, so subsequent kernels and the
@@ -562,7 +590,22 @@ namespace muGrid {
 #if defined(MUGRID_ENABLE_CUDA) || defined(MUGRID_ENABLE_HIP)
             GPU_DEVICE_SYNCHRONIZE();
 #endif
-            MPI_Sendrecv(send_staging, nb_send_blocks * send_block_len,
+            // Without GPU-aware MPI, bounce the contiguous send staging
+            // through host memory (the receive buffer is host already).
+            char * send_buffer{send_staging};
+            if (!mpi_is_gpu_aware()) {
+#if defined(MUGRID_ENABLE_CUDA) || defined(MUGRID_ENABLE_HIP)
+                auto & host_send{this->host_staging[0]};
+                if (host_send.size() < send_bytes) {
+                    host_send.resize(send_bytes);
+                }
+                if (send_bytes > 0) {
+                    GPU_MEMCPY_D2H(host_send.data(), send_staging, send_bytes);
+                }
+                send_buffer = host_send.data();
+#endif
+            }
+            MPI_Sendrecv(send_buffer, nb_send_blocks * send_block_len,
                          mpi_datatype, this->right_ranks[direction], 0,
                          recv_buffer.data(), total_recv_elems, mpi_datatype,
                          this->left_ranks[direction], 0, this->comm, &status);
@@ -648,7 +691,22 @@ namespace muGrid {
 #if defined(MUGRID_ENABLE_CUDA) || defined(MUGRID_ENABLE_HIP)
             GPU_DEVICE_SYNCHRONIZE();
 #endif
-            MPI_Sendrecv(send_staging, nb_send_blocks * send_block_len,
+            // Without GPU-aware MPI, bounce the contiguous send staging
+            // through host memory (the receive buffer is host already).
+            char * send_buffer{send_staging};
+            if (!mpi_is_gpu_aware()) {
+#if defined(MUGRID_ENABLE_CUDA) || defined(MUGRID_ENABLE_HIP)
+                auto & host_send{this->host_staging[0]};
+                if (host_send.size() < send_bytes) {
+                    host_send.resize(send_bytes);
+                }
+                if (send_bytes > 0) {
+                    GPU_MEMCPY_D2H(host_send.data(), send_staging, send_bytes);
+                }
+                send_buffer = host_send.data();
+#endif
+            }
+            MPI_Sendrecv(send_buffer, nb_send_blocks * send_block_len,
                          mpi_datatype, this->left_ranks[direction], 0,
                          recv_buffer.data(), total_recv_elems, mpi_datatype,
                          this->right_ranks[direction], 0, this->comm, &status);

--- a/src/libmugrid/mpi/cartesian_communicator.cc
+++ b/src/libmugrid/mpi/cartesian_communicator.cc
@@ -13,13 +13,8 @@
 #include <vector>
 #include "mpi/cartesian_communicator.hh"
 
-#if defined(MUGRID_ENABLE_CUDA)
-#include <cuda_runtime.h>
-#endif
-
-#if defined(MUGRID_ENABLE_HIP)
-#include <hip/hip_runtime.h>
-#endif
+#include "memory/device_alloc.hh"
+#include "memory/gpu_runtime.hh"
 
 namespace muGrid {
 
@@ -28,7 +23,10 @@ namespace muGrid {
          * @brief Copy strided memory blocks using appropriate method.
          *
          * Copies nb_blocks blocks of data, each of size block_len bytes,
-         * with blocks separated by pitch bytes in both source and destination.
+         * with blocks separated by dst_pitch bytes in the destination and
+         * src_pitch bytes in the source. Different pitches allow packing a
+         * strided layout into a contiguous buffer (dst_pitch == block_len)
+         * and unpacking it again.
          *
          * For GPU memory, uses hipMemcpy2D/cudaMemcpy2D for efficiency.
          * For host memory, falls back to individual memcpy calls.
@@ -37,32 +35,22 @@ namespace muGrid {
          * @param src Source address
          * @param block_len Size of each block in bytes (width)
          * @param nb_blocks Number of blocks to copy (height)
-         * @param pitch Stride between blocks in bytes
+         * @param dst_pitch Stride between blocks in the destination, bytes
+         * @param src_pitch Stride between blocks in the source, bytes
          * @param is_device_memory If true, use GPU device copy
          */
         void device_memcpy_strided(void * dst, const void * src,
                                    size_t block_len, size_t nb_blocks,
-                                   size_t pitch, bool is_device_memory) {
+                                   size_t dst_pitch, size_t src_pitch,
+                                   bool is_device_memory) {
             if (is_device_memory) {
-#if defined(MUGRID_ENABLE_CUDA)
-                // Use cudaMemcpy2D for efficient strided copy
-                // cudaMemcpy2D(dst, dpitch, src, spitch, width, height, kind)
-                (void)cudaMemcpy2D(dst, pitch, src, pitch, block_len, nb_blocks,
-                                   cudaMemcpyDeviceToDevice);
-#elif defined(MUGRID_ENABLE_HIP)
-                // Use hipMemcpy2D for efficient strided copy
-                // hipMemcpy2D(dst, dpitch, src, spitch, width, height, kind)
-                (void)hipMemcpy2D(dst, pitch, src, pitch, block_len, nb_blocks,
-                                  hipMemcpyDeviceToDevice);
+#if defined(MUGRID_ENABLE_CUDA) || defined(MUGRID_ENABLE_HIP)
+                GPU_MEMCPY_2D_D2D(dst, dst_pitch, src, src_pitch, block_len,
+                                  nb_blocks);
 #else
-                // Fallback to loop if no GPU backend
-                auto * dst_ptr = static_cast<char *>(dst);
-                auto * src_ptr = static_cast<const char *>(src);
-                for (size_t i{0}; i < nb_blocks; ++i) {
-                    std::memcpy(dst_ptr, src_ptr, block_len);
-                    dst_ptr += pitch;
-                    src_ptr += pitch;
-                }
+                throw RuntimeError(
+                    "device_memcpy_strided: muGrid was compiled without GPU "
+                    "support");
 #endif
             } else {
                 // Host memory: use loop of memcpy
@@ -70,8 +58,8 @@ namespace muGrid {
                 auto * src_ptr = static_cast<const char *>(src);
                 for (size_t i{0}; i < nb_blocks; ++i) {
                     std::memcpy(dst_ptr, src_ptr, block_len);
-                    dst_ptr += pitch;
-                    src_ptr += pitch;
+                    dst_ptr += dst_pitch;
+                    src_ptr += src_pitch;
                 }
             }
         }
@@ -203,7 +191,8 @@ namespace muGrid {
                                  elem_size_in_bytes};
             auto pitch_bytes{static_cast<size_t>(block_stride) * elem_size_in_bytes};
             device_memcpy_strided(recv_addr, send_addr, block_len_bytes,
-                                  nb_send_blocks, pitch_bytes, is_device_memory);
+                                  nb_send_blocks, pitch_bytes, pitch_bytes,
+                                  is_device_memory);
         }
 
         /**
@@ -323,6 +312,73 @@ namespace muGrid {
                 MPI_Comm_free(&this->comm);
             }
         }
+        for (auto & buffer : this->device_staging) {
+            if (buffer != nullptr) {
+                device_deallocate(buffer);
+            }
+        }
+    }
+
+    char * CartesianCommunicator::get_device_staging(std::size_t slot,
+                                                     std::size_t size) const {
+        auto & buffer{this->device_staging.at(slot)};
+        auto & current_size{this->device_staging_size.at(slot)};
+        if (current_size < size) {
+            if (buffer != nullptr) {
+                device_deallocate(buffer);
+                buffer = nullptr;
+                current_size = 0;
+            }
+            buffer = device_allocate(size);
+            current_size = size;
+        }
+        return static_cast<char *>(buffer);
+    }
+
+    void CartesianCommunicator::sendrecv_staged(
+        int block_stride, int nb_send_blocks, int send_block_len,
+        int nb_recv_blocks, int recv_block_len, void * send_addr,
+        void * recv_addr, int elem_size_in_bytes, MPI_Datatype mpi_datatype,
+        int dest_rank, int src_rank) const {
+        auto send_row_bytes{static_cast<std::size_t>(send_block_len) *
+                            elem_size_in_bytes};
+        auto recv_row_bytes{static_cast<std::size_t>(recv_block_len) *
+                            elem_size_in_bytes};
+        auto send_bytes{send_row_bytes * nb_send_blocks};
+        auto recv_bytes{recv_row_bytes * nb_recv_blocks};
+        auto pitch_bytes{static_cast<std::size_t>(block_stride) *
+                         elem_size_in_bytes};
+
+        char * send_staging{
+            send_bytes > 0 ? this->get_device_staging(0, send_bytes) : nullptr};
+        char * recv_staging{
+            recv_bytes > 0 ? this->get_device_staging(1, recv_bytes) : nullptr};
+
+        if (send_bytes > 0) {
+            // Gather the strided halo into the contiguous send buffer
+            device_memcpy_strided(send_staging, send_addr, send_row_bytes,
+                                  nb_send_blocks, send_row_bytes, pitch_bytes,
+                                  true);
+        }
+#if defined(MUGRID_ENABLE_CUDA) || defined(MUGRID_ENABLE_HIP)
+        // Device-to-device 2D copies are asynchronous with respect to the
+        // host; MPI must not read the staging buffer before the gather has
+        // completed.
+        GPU_DEVICE_SYNCHRONIZE();
+#endif
+        MPI_Status status;
+        MPI_Sendrecv(send_staging, nb_send_blocks * send_block_len,
+                     mpi_datatype, dest_rank, 0, recv_staging,
+                     nb_recv_blocks * recv_block_len, mpi_datatype, src_rank, 0,
+                     this->comm, &status);
+        if (recv_bytes > 0) {
+            // Scatter the contiguous receive buffer into the strided halo.
+            // This runs on the default stream, so subsequent kernels and the
+            // next pack are ordered after it.
+            device_memcpy_strided(recv_addr, recv_staging, recv_row_bytes,
+                                  nb_recv_blocks, pitch_bytes, recv_row_bytes,
+                                  true);
+        }
     }
 
     CartesianCommunicator &
@@ -367,10 +423,26 @@ namespace muGrid {
                             elem_size_in_bytes, is_device_memory);
             return;
         }
-        // Note: is_device_memory is not used in MPI mode - CUDA-aware MPI
-        // handles device pointers directly.
-        // Convert TypeDescriptor to MPI_Datatype
+        auto recv_addr{static_cast<void *>(
+            data + recv_offset * stride_in_direction * elem_size_in_bytes)};
+        auto send_addr{static_cast<void *>(
+            data + send_offset * stride_in_direction * elem_size_in_bytes)};
         MPI_Datatype mpi_datatype{descriptor_to_mpi_type(type_desc)};
+        MPI_Status status;
+
+        if (is_device_memory) {
+            // Strided derived datatypes on device pointers are packed block
+            // by block by the MPI implementation (orders of magnitude
+            // slower than a bulk copy); GPU-aware fast paths only apply to
+            // contiguous messages. Pack into contiguous device staging
+            // buffers, communicate flat, unpack.
+            this->sendrecv_staged(block_stride, nb_send_blocks, send_block_len,
+                                  nb_recv_blocks, recv_block_len, send_addr,
+                                  recv_addr, elem_size_in_bytes, mpi_datatype,
+                                  this->right_ranks[direction],
+                                  this->left_ranks[direction]);
+            return;
+        }
         MPI_Datatype send_buffer_mpi_t, recv_buffer_mpi_t;
         MPI_Type_vector(nb_send_blocks, send_block_len, block_stride,
                         mpi_datatype, &send_buffer_mpi_t);
@@ -378,12 +450,7 @@ namespace muGrid {
         MPI_Type_vector(nb_recv_blocks, recv_block_len, block_stride,
                         mpi_datatype, &recv_buffer_mpi_t);
         MPI_Type_commit(&recv_buffer_mpi_t);
-        auto recv_addr{static_cast<void *>(
-            data + recv_offset * stride_in_direction * elem_size_in_bytes)};
-        auto send_addr{static_cast<void *>(
-            data + send_offset * stride_in_direction * elem_size_in_bytes)};
 
-        MPI_Status status;
         MPI_Sendrecv(send_addr, 1, send_buffer_mpi_t,
                      this->right_ranks[direction], 0, recv_addr, 1,
                      recv_buffer_mpi_t, this->left_ranks[direction], 0,
@@ -409,10 +476,23 @@ namespace muGrid {
                             elem_size_in_bytes, is_device_memory);
             return;
         }
-        // Note: is_device_memory is not used in MPI mode - CUDA-aware MPI
-        // handles device pointers directly.
-        // Convert TypeDescriptor to MPI_Datatype
+        auto recv_addr{static_cast<void *>(
+            data + recv_offset * stride_in_direction * elem_size_in_bytes)};
+        auto send_addr{static_cast<void *>(
+            data + send_offset * stride_in_direction * elem_size_in_bytes)};
         MPI_Datatype mpi_datatype{descriptor_to_mpi_type(type_desc)};
+        MPI_Status status;
+
+        if (is_device_memory) {
+            // Contiguous staging for strided device halos (see
+            // sendrecv_right).
+            this->sendrecv_staged(block_stride, nb_send_blocks, send_block_len,
+                                  nb_recv_blocks, recv_block_len, send_addr,
+                                  recv_addr, elem_size_in_bytes, mpi_datatype,
+                                  this->left_ranks[direction],
+                                  this->right_ranks[direction]);
+            return;
+        }
         MPI_Datatype send_buffer_mpi_t, recv_buffer_mpi_t;
         MPI_Type_vector(nb_send_blocks, send_block_len, block_stride,
                         mpi_datatype, &send_buffer_mpi_t);
@@ -420,12 +500,7 @@ namespace muGrid {
         MPI_Type_vector(nb_recv_blocks, recv_block_len, block_stride,
                         mpi_datatype, &recv_buffer_mpi_t);
         MPI_Type_commit(&recv_buffer_mpi_t);
-        auto recv_addr{static_cast<void *>(
-            data + recv_offset * stride_in_direction * elem_size_in_bytes)};
-        auto send_addr{static_cast<void *>(
-            data + send_offset * stride_in_direction * elem_size_in_bytes)};
 
-        MPI_Status status;
         MPI_Sendrecv(send_addr, 1, send_buffer_mpi_t,
                      this->left_ranks[direction], 0, recv_addr, 1,
                      recv_buffer_mpi_t, this->right_ranks[direction], 0,
@@ -455,12 +530,6 @@ namespace muGrid {
         // Convert TypeDescriptor to MPI_Datatype
         MPI_Datatype mpi_datatype{descriptor_to_mpi_type(type_desc)};
 
-        // Create send type
-        MPI_Datatype send_buffer_mpi_t;
-        MPI_Type_vector(nb_send_blocks, send_block_len, block_stride,
-                        mpi_datatype, &send_buffer_mpi_t);
-        MPI_Type_commit(&send_buffer_mpi_t);
-
         // Calculate total receive size for temporary buffer
         auto total_recv_elems{static_cast<size_t>(nb_recv_blocks) *
                               static_cast<size_t>(recv_block_len)};
@@ -472,13 +541,46 @@ namespace muGrid {
             data + send_offset * stride_in_direction * elem_size_in_bytes)};
 
         MPI_Status status;
-        MPI_Sendrecv(send_addr, 1, send_buffer_mpi_t,
-                     this->right_ranks[direction], 0,
-                     recv_buffer.data(), total_recv_elems, mpi_datatype,
-                     this->left_ranks[direction], 0,
-                     this->comm, &status);
+        if (is_device_memory) {
+            // Gather the strided device send data into a contiguous device
+            // staging buffer (strided datatypes on device pointers are
+            // packed block by block by MPI, see sendrecv_staged). The
+            // receive side is already a contiguous host buffer.
+            auto send_row_bytes{static_cast<std::size_t>(send_block_len) *
+                                elem_size_in_bytes};
+            auto send_bytes{send_row_bytes * nb_send_blocks};
+            auto pitch_bytes{static_cast<std::size_t>(block_stride) *
+                             elem_size_in_bytes};
+            char * send_staging{
+                send_bytes > 0 ? this->get_device_staging(0, send_bytes)
+                               : nullptr};
+            if (send_bytes > 0) {
+                device_memcpy_strided(send_staging, send_addr, send_row_bytes,
+                                      nb_send_blocks, send_row_bytes,
+                                      pitch_bytes, true);
+            }
+#if defined(MUGRID_ENABLE_CUDA) || defined(MUGRID_ENABLE_HIP)
+            GPU_DEVICE_SYNCHRONIZE();
+#endif
+            MPI_Sendrecv(send_staging, nb_send_blocks * send_block_len,
+                         mpi_datatype, this->right_ranks[direction], 0,
+                         recv_buffer.data(), total_recv_elems, mpi_datatype,
+                         this->left_ranks[direction], 0, this->comm, &status);
+        } else {
+            // Create send type
+            MPI_Datatype send_buffer_mpi_t;
+            MPI_Type_vector(nb_send_blocks, send_block_len, block_stride,
+                            mpi_datatype, &send_buffer_mpi_t);
+            MPI_Type_commit(&send_buffer_mpi_t);
 
-        MPI_Type_free(&send_buffer_mpi_t);
+            MPI_Sendrecv(send_addr, 1, send_buffer_mpi_t,
+                         this->right_ranks[direction], 0,
+                         recv_buffer.data(), total_recv_elems, mpi_datatype,
+                         this->left_ranks[direction], 0,
+                         this->comm, &status);
+
+            MPI_Type_free(&send_buffer_mpi_t);
+        }
 
         // Accumulate received data into destination. The receive buffer is
         // contiguous (host memory); scatter it to the (possibly device) strided
@@ -516,12 +618,6 @@ namespace muGrid {
         // Convert TypeDescriptor to MPI_Datatype
         MPI_Datatype mpi_datatype{descriptor_to_mpi_type(type_desc)};
 
-        // Create send type
-        MPI_Datatype send_buffer_mpi_t;
-        MPI_Type_vector(nb_send_blocks, send_block_len, block_stride,
-                        mpi_datatype, &send_buffer_mpi_t);
-        MPI_Type_commit(&send_buffer_mpi_t);
-
         // Calculate total receive size for temporary buffer
         auto total_recv_elems{static_cast<size_t>(nb_recv_blocks) *
                               static_cast<size_t>(recv_block_len)};
@@ -533,13 +629,44 @@ namespace muGrid {
             data + send_offset * stride_in_direction * elem_size_in_bytes)};
 
         MPI_Status status;
-        MPI_Sendrecv(send_addr, 1, send_buffer_mpi_t,
-                     this->left_ranks[direction], 0,
-                     recv_buffer.data(), total_recv_elems, mpi_datatype,
-                     this->right_ranks[direction], 0,
-                     this->comm, &status);
+        if (is_device_memory) {
+            // Contiguous device staging for the strided send side (see
+            // sendrecv_right_accumulate).
+            auto send_row_bytes{static_cast<std::size_t>(send_block_len) *
+                                elem_size_in_bytes};
+            auto send_bytes{send_row_bytes * nb_send_blocks};
+            auto pitch_bytes{static_cast<std::size_t>(block_stride) *
+                             elem_size_in_bytes};
+            char * send_staging{
+                send_bytes > 0 ? this->get_device_staging(0, send_bytes)
+                               : nullptr};
+            if (send_bytes > 0) {
+                device_memcpy_strided(send_staging, send_addr, send_row_bytes,
+                                      nb_send_blocks, send_row_bytes,
+                                      pitch_bytes, true);
+            }
+#if defined(MUGRID_ENABLE_CUDA) || defined(MUGRID_ENABLE_HIP)
+            GPU_DEVICE_SYNCHRONIZE();
+#endif
+            MPI_Sendrecv(send_staging, nb_send_blocks * send_block_len,
+                         mpi_datatype, this->left_ranks[direction], 0,
+                         recv_buffer.data(), total_recv_elems, mpi_datatype,
+                         this->right_ranks[direction], 0, this->comm, &status);
+        } else {
+            // Create send type
+            MPI_Datatype send_buffer_mpi_t;
+            MPI_Type_vector(nb_send_blocks, send_block_len, block_stride,
+                            mpi_datatype, &send_buffer_mpi_t);
+            MPI_Type_commit(&send_buffer_mpi_t);
 
-        MPI_Type_free(&send_buffer_mpi_t);
+            MPI_Sendrecv(send_addr, 1, send_buffer_mpi_t,
+                         this->left_ranks[direction], 0,
+                         recv_buffer.data(), total_recv_elems, mpi_datatype,
+                         this->right_ranks[direction], 0,
+                         this->comm, &status);
+
+            MPI_Type_free(&send_buffer_mpi_t);
+        }
 
         // Accumulate received data into destination using a type- and
         // device-aware accumulation (the previous loop hard-coded Real and

--- a/src/libmugrid/mpi/cartesian_communicator.cc
+++ b/src/libmugrid/mpi/cartesian_communicator.cc
@@ -49,9 +49,12 @@ namespace muGrid {
                 GPU_MEMCPY_2D_D2D(dst, dst_pitch, src, src_pitch, block_len,
                                   nb_blocks);
 #else
+                // GCOVR_EXCL_START -- unreachable: device fields cannot be
+                // created in a build without a GPU backend
                 throw RuntimeError(
                     "device_memcpy_strided: muGrid was compiled without GPU "
                     "support");
+                // GCOVR_EXCL_STOP
 #endif
             } else {
                 // Host memory: use loop of memcpy
@@ -79,40 +82,34 @@ namespace muGrid {
          */
         template <typename T>
         void device_accumulate_typed(T * dst, const T * src, size_t nb_elements,
-                                     bool is_device_memory) {
-            if (is_device_memory) {
+                                     bool dst_on_device, bool src_on_device) {
+            if (dst_on_device) {
 #if defined(MUGRID_ENABLE_CUDA) || defined(MUGRID_ENABLE_HIP)
-                // For device memory, copy to host, accumulate, copy back
+                // For device memory, copy to host, accumulate, copy back.
                 // This is not optimal but works for correctness.
                 // A proper implementation would use a GPU kernel.
                 std::vector<T> host_dst(nb_elements);
-                std::vector<T> host_src(nb_elements);
-#if defined(MUGRID_ENABLE_CUDA)
-                cudaMemcpy(host_dst.data(), dst, nb_elements * sizeof(T),
-                           cudaMemcpyDeviceToHost);
-                cudaMemcpy(host_src.data(), src, nb_elements * sizeof(T),
-                           cudaMemcpyDeviceToHost);
-#elif defined(MUGRID_ENABLE_HIP)
-                (void)hipMemcpy(host_dst.data(), dst, nb_elements * sizeof(T),
-                                hipMemcpyDeviceToHost);
-                (void)hipMemcpy(host_src.data(), src, nb_elements * sizeof(T),
-                                hipMemcpyDeviceToHost);
-#endif
-                for (size_t i{0}; i < nb_elements; ++i) {
-                    host_dst[i] += host_src[i];
+                GPU_MEMCPY_D2H(host_dst.data(), dst, nb_elements * sizeof(T));
+                const T * src_values{src};
+                std::vector<T> host_src{};
+                if (src_on_device) {
+                    host_src.resize(nb_elements);
+                    GPU_MEMCPY_D2H(host_src.data(), src,
+                                   nb_elements * sizeof(T));
+                    src_values = host_src.data();
                 }
-#if defined(MUGRID_ENABLE_CUDA)
-                cudaMemcpy(dst, host_dst.data(), nb_elements * sizeof(T),
-                           cudaMemcpyHostToDevice);
-#elif defined(MUGRID_ENABLE_HIP)
-                (void)hipMemcpy(dst, host_dst.data(), nb_elements * sizeof(T),
-                                hipMemcpyHostToDevice);
-#endif
+                for (size_t i{0}; i < nb_elements; ++i) {
+                    host_dst[i] += src_values[i];
+                }
+                GPU_MEMCPY_H2D(dst, host_dst.data(), nb_elements * sizeof(T));
 #else
-                // Fallback: should not happen
+                // GCOVR_EXCL_START -- unreachable: device fields cannot be
+                // created in a build without a GPU backend
+                (void)src_on_device;
                 for (size_t i{0}; i < nb_elements; ++i) {
                     dst[i] += src[i];
                 }
+                // GCOVR_EXCL_STOP
 #endif
             } else {
                 for (size_t i{0}; i < nb_elements; ++i) {
@@ -133,32 +130,37 @@ namespace muGrid {
          */
         void accumulate_elements(char * dst, const char * src,
                                  size_t nb_elements, TypeDescriptor type_desc,
-                                 bool is_device_memory) {
+                                 bool dst_on_device, bool src_on_device) {
             switch (type_desc) {
             case TypeDescriptor::Real:
                 device_accumulate_typed(reinterpret_cast<Real *>(dst),
                                         reinterpret_cast<const Real *>(src),
-                                        nb_elements, is_device_memory);
+                                        nb_elements, dst_on_device,
+                                        src_on_device);
                 break;
             case TypeDescriptor::Complex:
                 device_accumulate_typed(reinterpret_cast<Complex *>(dst),
                                         reinterpret_cast<const Complex *>(src),
-                                        nb_elements, is_device_memory);
+                                        nb_elements, dst_on_device,
+                                        src_on_device);
                 break;
             case TypeDescriptor::Int:
                 device_accumulate_typed(reinterpret_cast<Int *>(dst),
                                         reinterpret_cast<const Int *>(src),
-                                        nb_elements, is_device_memory);
+                                        nb_elements, dst_on_device,
+                                        src_on_device);
                 break;
             case TypeDescriptor::Uint:
                 device_accumulate_typed(reinterpret_cast<Uint *>(dst),
                                         reinterpret_cast<const Uint *>(src),
-                                        nb_elements, is_device_memory);
+                                        nb_elements, dst_on_device,
+                                        src_on_device);
                 break;
             case TypeDescriptor::Index:
                 device_accumulate_typed(reinterpret_cast<Index_t *>(dst),
                                         reinterpret_cast<const Index_t *>(src),
-                                        nb_elements, is_device_memory);
+                                        nb_elements, dst_on_device,
+                                        src_on_device);
                 break;
             default:
                 throw std::runtime_error(
@@ -224,7 +226,8 @@ namespace muGrid {
                     base_data +
                     send_offset * stride_in_direction * elem_size_in_bytes};
                 accumulate_elements(recv_addr, send_addr, send_block_len,
-                                    type_desc, is_device_memory);
+                                    type_desc, is_device_memory,
+                                    is_device_memory);
                 base_data += block_stride * elem_size_in_bytes;
             }
         }
@@ -635,7 +638,7 @@ namespace muGrid {
                                      block * block_stride) * elem_size_in_bytes};
             accumulate_elements(dest_addr, recv_ptr,
                                 static_cast<size_t>(recv_block_len), type_desc,
-                                is_device_memory);
+                                is_device_memory, false);
             recv_ptr += recv_block_len * elem_size_in_bytes;
         }
     }
@@ -735,7 +738,7 @@ namespace muGrid {
                                      block * block_stride) * elem_size_in_bytes};
             accumulate_elements(dest_addr, recv_ptr,
                                 static_cast<size_t>(recv_block_len), type_desc,
-                                is_device_memory);
+                                is_device_memory, false);
             recv_ptr += recv_block_len * elem_size_in_bytes;
         }
     }

--- a/src/libmugrid/mpi/cartesian_communicator.hh
+++ b/src/libmugrid/mpi/cartesian_communicator.hh
@@ -40,6 +40,7 @@
 
 #include <array>
 #include <cstddef>
+#include <vector>
 
 #include "core/coordinates.hh"
 #include "core/type_descriptor.hh"
@@ -436,6 +437,9 @@ namespace muGrid {
         mutable std::array<void *, 2> device_staging{{nullptr, nullptr}};
         //! Sizes of the staging buffers in bytes
         mutable std::array<std::size_t, 2> device_staging_size{{0, 0}};
+        //! Host bounce buffers (send, recv) used when the MPI library is
+        //! not GPU-aware (see mpi/gpu_aware_mpi.hh)
+        mutable std::array<std::vector<char>, 2> host_staging{};
 #endif  // WITH_MPI
     };
 }  // namespace muGrid

--- a/src/libmugrid/mpi/cartesian_communicator.hh
+++ b/src/libmugrid/mpi/cartesian_communicator.hh
@@ -38,6 +38,9 @@
 #include <mpi.h>
 #endif
 
+#include <array>
+#include <cstddef>
+
 #include "core/coordinates.hh"
 #include "core/type_descriptor.hh"
 #include "mpi/communicator.hh"
@@ -403,6 +406,36 @@ namespace muGrid {
         //! true for the instance that created the topology via MPI_Cart_create;
         //! copies share the handle without taking ownership.
         bool owns_comm{false};
+
+        /**
+         * Return a cached contiguous device staging buffer of at least
+         * `size` bytes (slot 0: send, slot 1: receive). Strided device
+         * halos are packed into these buffers before communication: MPI
+         * implementations pack strided datatypes on device memory block
+         * by block, which is orders of magnitude slower than a device-side
+         * gather followed by a contiguous transfer. Buffers grow on
+         * demand and live for the communicator's lifetime; they are
+         * per-instance and not copied.
+         */
+        char * get_device_staging(std::size_t slot, std::size_t size) const;
+
+        /**
+         * Exchange strided device data through contiguous staging buffers:
+         * pack (device gather) → MPI_Sendrecv of flat bytes → unpack
+         * (device scatter). Used instead of strided derived datatypes for
+         * device memory; see get_device_staging.
+         */
+        void sendrecv_staged(int block_stride, int nb_send_blocks,
+                             int send_block_len, int nb_recv_blocks,
+                             int recv_block_len, void * send_addr,
+                             void * recv_addr, int elem_size_in_bytes,
+                             MPI_Datatype mpi_datatype, int dest_rank,
+                             int src_rank) const;
+
+        //! Contiguous device staging buffers for halo exchange (send, recv)
+        mutable std::array<void *, 2> device_staging{{nullptr, nullptr}};
+        //! Sizes of the staging buffers in bytes
+        mutable std::array<std::size_t, 2> device_staging_size{{0, 0}};
 #endif  // WITH_MPI
     };
 }  // namespace muGrid

--- a/src/libmugrid/mpi/gpu_aware_mpi.cc
+++ b/src/libmugrid/mpi/gpu_aware_mpi.cc
@@ -1,0 +1,78 @@
+/**
+ * @file   mpi/gpu_aware_mpi.cc
+ *
+ * @author Lars Pastewka <lars.pastewka@imtek.uni-freiburg.de>
+ *
+ * @date   12 Jun 2026
+ *
+ * @brief  Runtime detection of GPU-aware MPI
+ *
+ * Copyright © 2026 Lars Pastewka
+ *
+ * µGrid is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3, or (at
+ * your option) any later version.
+ *
+ * µGrid is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with µGrid; see the file COPYING. If not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ * Additional permission under GNU GPL version 3 section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with proprietary FFT implementations or numerical libraries, containing parts
+ * covered by the terms of those libraries' licenses, the licensors of this
+ * Program grant you additional permission to convey the resulting work.
+ */
+
+#include "mpi/gpu_aware_mpi.hh"
+
+#include <cstdlib>
+#include <cstring>
+
+#ifdef WITH_MPI
+#include <mpi.h>
+#if defined(OPEN_MPI)
+#include <mpi-ext.h>
+#endif
+#endif
+
+namespace muGrid {
+
+    namespace {
+        bool detect_gpu_aware_mpi() {
+            const char * env{std::getenv("MUGRID_GPU_AWARE_MPI")};
+            if (env != nullptr && std::strlen(env) > 0) {
+                return env[0] == '1' || env[0] == 'y' || env[0] == 'Y' ||
+                       env[0] == 't' || env[0] == 'T';
+            }
+#if defined(WITH_MPI) && defined(MPIX_CUDA_AWARE_SUPPORT)
+            if (MPIX_Query_cuda_support()) {
+                return true;
+            }
+#endif
+#if defined(WITH_MPI) && defined(MPIX_ROCM_AWARE_SUPPORT)
+            if (MPIX_Query_rocm_support()) {
+                return true;
+            }
+#endif
+            // Unknown MPI stack (or one built without GPU support):
+            // bounce device buffers through host staging, which is correct
+            // with any MPI.
+            return false;
+        }
+    }  // namespace
+
+    bool mpi_is_gpu_aware() {
+        static bool gpu_aware{detect_gpu_aware_mpi()};
+        return gpu_aware;
+    }
+
+}  // namespace muGrid

--- a/src/libmugrid/mpi/gpu_aware_mpi.hh
+++ b/src/libmugrid/mpi/gpu_aware_mpi.hh
@@ -1,0 +1,62 @@
+/**
+ * @file   mpi/gpu_aware_mpi.hh
+ *
+ * @author Lars Pastewka <lars.pastewka@imtek.uni-freiburg.de>
+ *
+ * @date   12 Jun 2026
+ *
+ * @brief  Runtime detection of GPU-aware MPI
+ *
+ * muGrid communicates device data as contiguous staging buffers. A
+ * GPU-aware MPI can take those device pointers directly; a plain MPI
+ * build would dereference them on the host and crash, so the
+ * communication routines bounce the staging buffers through host memory
+ * instead. This header provides the runtime decision.
+ *
+ * Copyright © 2026 Lars Pastewka
+ *
+ * µGrid is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3, or (at
+ * your option) any later version.
+ *
+ * µGrid is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with µGrid; see the file COPYING. If not, write to the
+ * Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+ * Boston, MA 02111-1307, USA.
+ *
+ * Additional permission under GNU GPL version 3 section 7
+ *
+ * If you modify this Program, or any covered work, by linking or combining it
+ * with proprietary FFT implementations or numerical libraries, containing parts
+ * covered by the terms of those libraries' licenses, the licensors of this
+ * Program grant you additional permission to convey the resulting work.
+ */
+
+#ifndef SRC_LIBMUGRID_MPI_GPU_AWARE_MPI_HH_
+#define SRC_LIBMUGRID_MPI_GPU_AWARE_MPI_HH_
+
+namespace muGrid {
+
+    /**
+     * True if the MPI library can take device pointers directly
+     * (GPU-aware MPI). The result is determined once and cached:
+     *
+     * 1. The environment variable ``MUGRID_GPU_AWARE_MPI`` (``1``/``0``)
+     *    overrides any detection — use it for MPI stacks whose support
+     *    cannot be queried, or to force the host-staging fallback.
+     * 2. Open MPI is queried via ``MPIX_Query_cuda_support()`` /
+     *    ``MPIX_Query_rocm_support()`` where available.
+     * 3. Otherwise the conservative answer is false: device buffers are
+     *    bounced through host staging, which is correct with any MPI.
+     */
+    bool mpi_is_gpu_aware();
+
+}  // namespace muGrid
+
+#endif  // SRC_LIBMUGRID_MPI_GPU_AWARE_MPI_HH_

--- a/src/libmugrid/operators/convolution_kernels_gpu.hh
+++ b/src/libmugrid/operators/convolution_kernels_gpu.hh
@@ -45,18 +45,7 @@
 #include "core/types.hh"
 #include "convolution_kernels_cpu.hh"  // For GridTraversalParams
 
-// Unified GPU abstraction
-#if defined(MUGRID_ENABLE_CUDA)
-    #include <cuda_runtime.h>
-    #define GPU_LAUNCH_KERNEL(kernel, grid, block, stream, ...) \
-        kernel<<<grid, block, 0, stream>>>(__VA_ARGS__)
-    using gpuStream_t = cudaStream_t;
-#elif defined(MUGRID_ENABLE_HIP)
-    #include <hip/hip_runtime.h>
-    #define GPU_LAUNCH_KERNEL(kernel, grid, block, stream, ...) \
-        hipLaunchKernelGGL(kernel, grid, block, 0, stream, __VA_ARGS__)
-    using gpuStream_t = hipStream_t;
-#endif
+#include "memory/gpu_runtime.hh"
 
 namespace muGrid {
 
@@ -182,7 +171,7 @@ namespace gpu {
             (params.nz + block.z - 1) / block.z
         );
 
-        GPU_LAUNCH_KERNEL(apply_convolution_kernel_impl, grid, block, stream,
+        GPU_LAUNCH_KERNEL_STREAM(apply_convolution_kernel_impl, grid, block, stream,
             nodal_data, quad_data, alpha,
             params.nx, params.ny, params.nz,
             nodal_base, quad_base,
@@ -223,7 +212,7 @@ namespace gpu {
             (params.nz + block.z - 1) / block.z
         );
 
-        GPU_LAUNCH_KERNEL(transpose_convolution_kernel_impl, grid, block, stream,
+        GPU_LAUNCH_KERNEL_STREAM(transpose_convolution_kernel_impl, grid, block, stream,
             quad_data, nodal_data, alpha,
             params.nx, params.ny, params.nz,
             nodal_base, quad_base,

--- a/src/libmugrid/operators/fem_gradient_gpu.cc
+++ b/src/libmugrid/operators/fem_gradient_gpu.cc
@@ -40,18 +40,7 @@
 #include "fem_gradient_2d.hh"
 #include "fem_gradient_3d.hh"
 
-// Unified GPU abstraction macros
-#if defined(MUGRID_ENABLE_CUDA)
-    #include <cuda_runtime.h>
-    #define GPU_LAUNCH_KERNEL(kernel, grid, block, ...) \
-        kernel<<<grid, block>>>(__VA_ARGS__)
-    #define GPU_DEVICE_SYNCHRONIZE() (void)cudaDeviceSynchronize()
-#elif defined(MUGRID_ENABLE_HIP)
-    #include <hip/hip_runtime.h>
-    #define GPU_LAUNCH_KERNEL(kernel, grid, block, ...) \
-        hipLaunchKernelGGL(kernel, grid, block, 0, 0, __VA_ARGS__)
-    #define GPU_DEVICE_SYNCHRONIZE() (void)hipDeviceSynchronize()
-#endif
+#include "memory/gpu_runtime.hh"
 
 namespace muGrid {
 namespace fem_gradient_kernels {

--- a/src/libmugrid/operators/laplace_gpu.cc
+++ b/src/libmugrid/operators/laplace_gpu.cc
@@ -42,21 +42,7 @@
 #include <vector>
 
 // Unified GPU abstraction macros
-#if defined(MUGRID_ENABLE_CUDA)
-    #include <cuda_runtime.h>
-    #define GPU_LAUNCH_KERNEL(kernel, grid, block, ...) \
-        kernel<<<grid, block>>>(__VA_ARGS__)
-    #define GPU_LAUNCH_KERNEL_SHMEM(kernel, grid, block, shmem, ...) \
-        kernel<<<grid, block, shmem>>>(__VA_ARGS__)
-    #define GPU_DEVICE_SYNCHRONIZE() (void)cudaDeviceSynchronize()
-#elif defined(MUGRID_ENABLE_HIP)
-    #include <hip/hip_runtime.h>
-    #define GPU_LAUNCH_KERNEL(kernel, grid, block, ...) \
-        hipLaunchKernelGGL(kernel, grid, block, 0, 0, __VA_ARGS__)
-    #define GPU_LAUNCH_KERNEL_SHMEM(kernel, grid, block, shmem, ...) \
-        hipLaunchKernelGGL(kernel, grid, block, shmem, 0, __VA_ARGS__)
-    #define GPU_DEVICE_SYNCHRONIZE() (void)hipDeviceSynchronize()
-#endif
+#include "memory/gpu_runtime.hh"
 
 namespace muGrid {
 namespace laplace_kernels {

--- a/src/libmugrid/operators/solids/isotropic_stiffness_2d.hh
+++ b/src/libmugrid/operators/solids/isotropic_stiffness_2d.hh
@@ -235,18 +235,8 @@ namespace muGrid {
             Index_t force_stride_y, Index_t force_stride_d, const Real * G,
             const Real * V, Real alpha, bool increment);
 
-#if defined(MUGRID_ENABLE_CUDA)
-        void isotropic_stiffness_2d_cuda(
-            const Real * displacement, const Real * lambda, const Real * mu,
-            Real * force, Index_t nnx, Index_t nny, Index_t nelx, Index_t nely,
-            Index_t disp_stride_x, Index_t disp_stride_y, Index_t disp_stride_d,
-            Index_t mat_stride_x, Index_t mat_stride_y, Index_t force_stride_x,
-            Index_t force_stride_y, Index_t force_stride_d, const Real * G,
-            const Real * V, Real alpha, bool increment);
-#endif
-
-#if defined(MUGRID_ENABLE_HIP)
-        void isotropic_stiffness_2d_hip(
+#if defined(MUGRID_ENABLE_CUDA) || defined(MUGRID_ENABLE_HIP)
+        void isotropic_stiffness_2d_gpu(
             const Real * displacement, const Real * lambda, const Real * mu,
             Real * force, Index_t nnx, Index_t nny, Index_t nelx, Index_t nely,
             Index_t disp_stride_x, Index_t disp_stride_y, Index_t disp_stride_d,

--- a/src/libmugrid/operators/solids/isotropic_stiffness_3d.hh
+++ b/src/libmugrid/operators/solids/isotropic_stiffness_3d.hh
@@ -240,23 +240,8 @@ namespace muGrid {
             const Real* G, const Real* V,
             Real alpha, bool increment);
 
-#if defined(MUGRID_ENABLE_CUDA)
-        void isotropic_stiffness_3d_cuda(
-            const Real* displacement, const Real* lambda, const Real* mu,
-            Real* force,
-            Index_t nnx, Index_t nny, Index_t nnz,
-            Index_t nelx, Index_t nely, Index_t nelz,
-            Index_t disp_stride_x, Index_t disp_stride_y, Index_t disp_stride_z,
-            Index_t disp_stride_d,
-            Index_t mat_stride_x, Index_t mat_stride_y, Index_t mat_stride_z,
-            Index_t force_stride_x, Index_t force_stride_y, Index_t force_stride_z,
-            Index_t force_stride_d,
-            const Real* G, const Real* V,
-            Real alpha, bool increment);
-#endif
-
-#if defined(MUGRID_ENABLE_HIP)
-        void isotropic_stiffness_3d_hip(
+#if defined(MUGRID_ENABLE_CUDA) || defined(MUGRID_ENABLE_HIP)
+        void isotropic_stiffness_3d_gpu(
             const Real* displacement, const Real* lambda, const Real* mu,
             Real* force,
             Index_t nnx, Index_t nny, Index_t nnz,

--- a/src/libmugrid/operators/solids/isotropic_stiffness_gpu.cc
+++ b/src/libmugrid/operators/solids/isotropic_stiffness_gpu.cc
@@ -38,11 +38,7 @@
 #include "collection/field_collection_global.hh"
 #include "core/exception.hh"
 
-#if defined(MUGRID_ENABLE_CUDA)
-#include <cuda_runtime.h>
-#elif defined(MUGRID_ENABLE_HIP)
-#include <hip/hip_runtime.h>
-#endif
+#include "memory/gpu_runtime.hh"
 
 #if defined(MUGRID_ENABLE_CUDA) || defined(MUGRID_ENABLE_HIP)
 
@@ -298,9 +294,7 @@ __global__ void isotropic_stiffness_3d_kernel(
 
 namespace isotropic_stiffness_kernels {
 
-#if defined(MUGRID_ENABLE_CUDA)
-
-void isotropic_stiffness_2d_cuda(
+void isotropic_stiffness_2d_gpu(
     const Real* displacement, const Real* lambda, const Real* mu,
     Real* force,
     Index_t nnx, Index_t nny,
@@ -316,14 +310,14 @@ void isotropic_stiffness_2d_cuda(
     // would make a second operator with a different spacing silently use the
     // first one's matrices. The default-stream ordering makes the copy safe
     // (the kernel below runs after it).
-    cudaMemcpyToSymbol(d_G_2D, G, 64 * sizeof(Real));
-    cudaMemcpyToSymbol(d_V_2D, V, 64 * sizeof(Real));
+    GPU_MEMCPY_TO_SYMBOL(d_G_2D, G, 64 * sizeof(Real));
+    GPU_MEMCPY_TO_SYMBOL(d_V_2D, V, 64 * sizeof(Real));
 
     // Launch stiffness kernel - one thread per interior NODE
     dim3 block(16, 16);
     dim3 grid((nnx + block.x - 1) / block.x, (nny + block.y - 1) / block.y);
 
-    isotropic_stiffness_2d_kernel<<<grid, block>>>(
+    GPU_LAUNCH_KERNEL(isotropic_stiffness_2d_kernel, grid, block,
         displacement, lambda, mu, force,
         nnx, nny, nelx, nely,
         disp_stride_x, disp_stride_y, disp_stride_d,
@@ -332,14 +326,13 @@ void isotropic_stiffness_2d_cuda(
         alpha, increment);
 
     // Check for errors
-    cudaError_t err = cudaGetLastError();
-    if (err != cudaSuccess) {
-        throw RuntimeError("CUDA kernel launch failed: " +
-                          std::string(cudaGetErrorString(err)));
+    const char * err{gpu_last_error()};
+    if (err != nullptr) {
+        throw RuntimeError("GPU kernel launch failed: " + std::string(err));
     }
 }
 
-void isotropic_stiffness_3d_cuda(
+void isotropic_stiffness_3d_gpu(
     const Real* displacement, const Real* lambda, const Real* mu,
     Real* force,
     Index_t nnx, Index_t nny, Index_t nnz,
@@ -355,8 +348,8 @@ void isotropic_stiffness_3d_cuda(
     // Copy this instance's G and V to constant memory before every launch (see
     // the 2D variant: the matrices depend on grid_spacing, so a one-shot upload
     // would let a second operator silently reuse the first one's matrices).
-    cudaMemcpyToSymbol(d_G_3D, G, 576 * sizeof(Real));
-    cudaMemcpyToSymbol(d_V_3D, V, 576 * sizeof(Real));
+    GPU_MEMCPY_TO_SYMBOL(d_G_3D, G, 576 * sizeof(Real));
+    GPU_MEMCPY_TO_SYMBOL(d_V_3D, V, 576 * sizeof(Real));
 
     // Launch stiffness kernel - one thread per interior NODE
     dim3 block(8, 8, 4);
@@ -364,7 +357,7 @@ void isotropic_stiffness_3d_cuda(
               (nny + block.y - 1) / block.y,
               (nnz + block.z - 1) / block.z);
 
-    isotropic_stiffness_3d_kernel<<<grid, block>>>(
+    GPU_LAUNCH_KERNEL(isotropic_stiffness_3d_kernel, grid, block,
         displacement, lambda, mu, force,
         nnx, nny, nnz, nelx, nely, nelz,
         disp_stride_x, disp_stride_y, disp_stride_z, disp_stride_d,
@@ -373,102 +366,17 @@ void isotropic_stiffness_3d_cuda(
         alpha, increment);
 
     // Check for errors
-    cudaError_t err = cudaGetLastError();
-    if (err != cudaSuccess) {
-        throw RuntimeError("CUDA kernel launch failed: " +
-                          std::string(cudaGetErrorString(err)));
+    const char * err{gpu_last_error()};
+    if (err != nullptr) {
+        throw RuntimeError("GPU kernel launch failed: " + std::string(err));
     }
 }
-
-#endif  // MUGRID_ENABLE_CUDA
-
-#if defined(MUGRID_ENABLE_HIP)
-
-void isotropic_stiffness_2d_hip(
-    const Real* displacement, const Real* lambda, const Real* mu,
-    Real* force,
-    Index_t nnx, Index_t nny,
-    Index_t nelx, Index_t nely,
-    Index_t disp_stride_x, Index_t disp_stride_y, Index_t disp_stride_d,
-    Index_t mat_stride_x, Index_t mat_stride_y,
-    Index_t force_stride_x, Index_t force_stride_y, Index_t force_stride_d,
-    const Real* G, const Real* V,
-    Real alpha, bool increment) {
-
-    // Copy this instance's G and V before every launch (the matrices depend on
-    // grid_spacing; a one-shot upload would let a second operator silently
-    // reuse the first one's matrices). Default-stream ordering makes this safe.
-    hipMemcpyToSymbol(d_G_2D, G, 64 * sizeof(Real));
-    hipMemcpyToSymbol(d_V_2D, V, 64 * sizeof(Real));
-
-    // Launch stiffness kernel - one thread per interior NODE
-    dim3 block(16, 16);
-    dim3 grid((nnx + block.x - 1) / block.x, (nny + block.y - 1) / block.y);
-
-    hipLaunchKernelGGL(isotropic_stiffness_2d_kernel, grid, block, 0, 0,
-        displacement, lambda, mu, force,
-        nnx, nny, nelx, nely,
-        disp_stride_x, disp_stride_y, disp_stride_d,
-        mat_stride_x, mat_stride_y,
-        force_stride_x, force_stride_y, force_stride_d,
-        alpha, increment);
-
-    // Check for errors
-    hipError_t err = hipGetLastError();
-    if (err != hipSuccess) {
-        throw RuntimeError("HIP kernel launch failed: " +
-                          std::string(hipGetErrorString(err)));
-    }
-}
-
-void isotropic_stiffness_3d_hip(
-    const Real* displacement, const Real* lambda, const Real* mu,
-    Real* force,
-    Index_t nnx, Index_t nny, Index_t nnz,
-    Index_t nelx, Index_t nely, Index_t nelz,
-    Index_t disp_stride_x, Index_t disp_stride_y, Index_t disp_stride_z,
-    Index_t disp_stride_d,
-    Index_t mat_stride_x, Index_t mat_stride_y, Index_t mat_stride_z,
-    Index_t force_stride_x, Index_t force_stride_y, Index_t force_stride_z,
-    Index_t force_stride_d,
-    const Real* G, const Real* V,
-    Real alpha, bool increment) {
-
-    // Copy this instance's G and V before every launch (see the 2D variant).
-    hipMemcpyToSymbol(d_G_3D, G, 576 * sizeof(Real));
-    hipMemcpyToSymbol(d_V_3D, V, 576 * sizeof(Real));
-
-    // Launch stiffness kernel - one thread per interior NODE
-    dim3 block(8, 8, 4);
-    dim3 grid((nnx + block.x - 1) / block.x,
-              (nny + block.y - 1) / block.y,
-              (nnz + block.z - 1) / block.z);
-
-    hipLaunchKernelGGL(isotropic_stiffness_3d_kernel, grid, block, 0, 0,
-        displacement, lambda, mu, force,
-        nnx, nny, nnz, nelx, nely, nelz,
-        disp_stride_x, disp_stride_y, disp_stride_z, disp_stride_d,
-        mat_stride_x, mat_stride_y, mat_stride_z,
-        force_stride_x, force_stride_y, force_stride_z, force_stride_d,
-        alpha, increment);
-
-    // Check for errors
-    hipError_t err = hipGetLastError();
-    if (err != hipSuccess) {
-        throw RuntimeError("HIP kernel launch failed: " +
-                          std::string(hipGetErrorString(err)));
-    }
-}
-
-#endif  // MUGRID_ENABLE_HIP
 
 }  // namespace isotropic_stiffness_kernels
 
 // ============================================================================
 // Class Method Implementations for GPU
 // ============================================================================
-
-#if defined(MUGRID_ENABLE_CUDA)
 
 void IsotropicStiffnessOperator2D::apply(
     const TypedFieldBase<Real, DefaultDeviceSpace>& displacement,
@@ -591,7 +499,7 @@ void IsotropicStiffnessOperator2D::apply_impl(
     Index_t mat_offset = mat_ghost_offset_x * mat_stride_x +
                          mat_ghost_offset_y * mat_stride_y;
 
-    isotropic_stiffness_kernels::isotropic_stiffness_2d_cuda(
+    isotropic_stiffness_kernels::isotropic_stiffness_2d_gpu(
         displacement.view().data() + disp_offset,
         lambda.view().data() + mat_offset,
         mu.view().data() + mat_offset,
@@ -739,7 +647,7 @@ void IsotropicStiffnessOperator3D::apply_impl(
                          mat_ghost_offset_y * mat_stride_y +
                          mat_ghost_offset_z * mat_stride_z;
 
-    isotropic_stiffness_kernels::isotropic_stiffness_3d_cuda(
+    isotropic_stiffness_kernels::isotropic_stiffness_3d_gpu(
         displacement.view().data() + disp_offset,
         lambda.view().data() + mat_offset,
         mu.view().data() + mat_offset,
@@ -752,293 +660,6 @@ void IsotropicStiffnessOperator3D::apply_impl(
         G_matrix.data(), V_matrix.data(),
         alpha, increment);
 }
-
-#elif defined(MUGRID_ENABLE_HIP)
-
-void IsotropicStiffnessOperator2D::apply(
-    const TypedFieldBase<Real, DefaultDeviceSpace>& displacement,
-    const TypedFieldBase<Real, DefaultDeviceSpace>& lambda,
-    const TypedFieldBase<Real, DefaultDeviceSpace>& mu,
-    TypedFieldBase<Real, DefaultDeviceSpace>& force) const {
-    apply_impl(displacement, lambda, mu, 1.0, force, false);
-}
-
-void IsotropicStiffnessOperator2D::apply_increment(
-    const TypedFieldBase<Real, DefaultDeviceSpace>& displacement,
-    const TypedFieldBase<Real, DefaultDeviceSpace>& lambda,
-    const TypedFieldBase<Real, DefaultDeviceSpace>& mu,
-    Real alpha,
-    TypedFieldBase<Real, DefaultDeviceSpace>& force) const {
-    apply_impl(displacement, lambda, mu, alpha, force, true);
-}
-
-void IsotropicStiffnessOperator2D::apply_impl(
-    const TypedFieldBase<Real, DefaultDeviceSpace>& displacement,
-    const TypedFieldBase<Real, DefaultDeviceSpace>& lambda,
-    const TypedFieldBase<Real, DefaultDeviceSpace>& mu,
-    Real alpha,
-    TypedFieldBase<Real, DefaultDeviceSpace>& force,
-    bool increment) const {
-
-    auto& disp_coll = displacement.get_collection();
-    auto* disp_global_fc = dynamic_cast<const GlobalFieldCollection*>(&disp_coll);
-    if (!disp_global_fc) {
-        throw RuntimeError("IsotropicStiffnessOperator2D requires GlobalFieldCollection");
-    }
-
-    // Get dimensions from material field collection
-    auto& mat_coll = lambda.get_collection();
-    auto* mat_global_fc = dynamic_cast<const GlobalFieldCollection*>(&mat_coll);
-    if (!mat_global_fc) {
-        throw RuntimeError("IsotropicStiffnessOperator2D material fields require GlobalFieldCollection");
-    }
-
-    // Validate ghost configuration for displacement/force fields
-    auto nb_ghosts_left = disp_global_fc->get_nb_ghosts_left();
-    auto nb_ghosts_right = disp_global_fc->get_nb_ghosts_right();
-    if (nb_ghosts_left[0] < 1 || nb_ghosts_left[1] < 1) {
-        throw RuntimeError(
-            "IsotropicStiffnessOperator2D requires at least 1 ghost cell on the "
-            "left side of displacement/force fields");
-    }
-    if (nb_ghosts_right[0] < 1 || nb_ghosts_right[1] < 1) {
-        throw RuntimeError(
-            "IsotropicStiffnessOperator2D requires at least 1 ghost cell on the "
-            "right side of displacement/force fields");
-    }
-
-    // Stencil requirements: 1 left, 1 right ghost needed
-    constexpr Index_t STENCIL_LEFT = 1;
-    constexpr Index_t STENCIL_RIGHT = 1;
-
-    // Compute computable region: total with ghosts minus stencil requirements
-    auto nb_with_ghosts = disp_global_fc->get_nb_subdomain_grid_pts_with_ghosts();
-    Index_t nnx = nb_with_ghosts[0] - STENCIL_LEFT - STENCIL_RIGHT;
-    Index_t nny = nb_with_ghosts[1] - STENCIL_LEFT - STENCIL_RIGHT;
-
-    // Material field dimensions (computable region)
-    auto mat_nb_with_ghosts = mat_global_fc->get_nb_subdomain_grid_pts_with_ghosts();
-    Index_t nelx = mat_nb_with_ghosts[0] - STENCIL_LEFT - STENCIL_RIGHT;
-    Index_t nely = mat_nb_with_ghosts[1] - STENCIL_LEFT - STENCIL_RIGHT;
-
-    // Validate material field computable region matches node field
-    if (nelx != nnx || nely != nny) {
-        throw RuntimeError(
-            "IsotropicStiffnessOperator2D: material field computable region (" +
-            std::to_string(nelx) + ", " + std::to_string(nely) +
-            ") must match node field computable region (" +
-            std::to_string(nnx) + ", " + std::to_string(nny) + ")");
-    }
-
-    // Validate material field ghost configuration
-    auto mat_nb_ghosts_left = mat_global_fc->get_nb_ghosts_left();
-    auto mat_nb_ghosts_right = mat_global_fc->get_nb_ghosts_right();
-    if (mat_nb_ghosts_left[0] < 1 || mat_nb_ghosts_left[1] < 1) {
-        throw RuntimeError("IsotropicStiffnessOperator2D requires at least "
-                           "1 ghost cell on the left side of material fields");
-    }
-    if (mat_nb_ghosts_right[0] < 1 || mat_nb_ghosts_right[1] < 1) {
-        throw RuntimeError("IsotropicStiffnessOperator2D requires at least "
-                           "1 ghost cell on the right side of material fields");
-    }
-
-    // Node dimensions (for displacement/force fields with ghosts)
-    Index_t nx = nb_with_ghosts[0];
-    Index_t ny = nb_with_ghosts[1];
-
-    // Material field dimensions with ghosts
-    Index_t mat_nx = mat_nb_with_ghosts[0];
-    Index_t mat_ny = mat_nb_with_ghosts[1];
-
-    // Offset to first computable node (based on stencil requirements)
-    Index_t ghost_offset_x = STENCIL_LEFT;
-    Index_t ghost_offset_y = STENCIL_LEFT;
-    Index_t mat_ghost_offset_x = STENCIL_LEFT;
-    Index_t mat_ghost_offset_y = STENCIL_LEFT;
-
-    // GPU uses SoA layout: [d, x, y]
-    Index_t disp_stride_d = nx * ny;
-    Index_t disp_stride_x = 1;
-    Index_t disp_stride_y = nx;
-
-    Index_t mat_stride_x = 1;
-    Index_t mat_stride_y = mat_nx;
-
-    Index_t force_stride_d = nx * ny;
-    Index_t force_stride_x = 1;
-    Index_t force_stride_y = nx;
-
-    // Offset data pointers to account for left ghosts
-    Index_t disp_offset = ghost_offset_x * disp_stride_x +
-                          ghost_offset_y * disp_stride_y;
-    Index_t force_offset = ghost_offset_x * force_stride_x +
-                           ghost_offset_y * force_stride_y;
-    Index_t mat_offset = mat_ghost_offset_x * mat_stride_x +
-                         mat_ghost_offset_y * mat_stride_y;
-
-    isotropic_stiffness_kernels::isotropic_stiffness_2d_hip(
-        displacement.view().data() + disp_offset,
-        lambda.view().data() + mat_offset,
-        mu.view().data() + mat_offset,
-        force.view().data() + force_offset,
-        nnx, nny,  // Number of interior nodes
-        nelx, nely,  // Number of elements (same as nodes)
-        disp_stride_x, disp_stride_y, disp_stride_d,
-        mat_stride_x, mat_stride_y,
-        force_stride_x, force_stride_y, force_stride_d,
-        G_matrix.data(), V_matrix.data(),
-        alpha, increment);
-}
-
-void IsotropicStiffnessOperator3D::apply(
-    const TypedFieldBase<Real, DefaultDeviceSpace>& displacement,
-    const TypedFieldBase<Real, DefaultDeviceSpace>& lambda,
-    const TypedFieldBase<Real, DefaultDeviceSpace>& mu,
-    TypedFieldBase<Real, DefaultDeviceSpace>& force) const {
-    apply_impl(displacement, lambda, mu, 1.0, force, false);
-}
-
-void IsotropicStiffnessOperator3D::apply_increment(
-    const TypedFieldBase<Real, DefaultDeviceSpace>& displacement,
-    const TypedFieldBase<Real, DefaultDeviceSpace>& lambda,
-    const TypedFieldBase<Real, DefaultDeviceSpace>& mu,
-    Real alpha,
-    TypedFieldBase<Real, DefaultDeviceSpace>& force) const {
-    apply_impl(displacement, lambda, mu, alpha, force, true);
-}
-
-void IsotropicStiffnessOperator3D::apply_impl(
-    const TypedFieldBase<Real, DefaultDeviceSpace>& displacement,
-    const TypedFieldBase<Real, DefaultDeviceSpace>& lambda,
-    const TypedFieldBase<Real, DefaultDeviceSpace>& mu,
-    Real alpha,
-    TypedFieldBase<Real, DefaultDeviceSpace>& force,
-    bool increment) const {
-
-    auto& disp_coll = displacement.get_collection();
-    auto* disp_global_fc = dynamic_cast<const GlobalFieldCollection*>(&disp_coll);
-    if (!disp_global_fc) {
-        throw RuntimeError("IsotropicStiffnessOperator3D requires GlobalFieldCollection");
-    }
-
-    // Get dimensions from material field collection
-    auto& mat_coll = lambda.get_collection();
-    auto* mat_global_fc = dynamic_cast<const GlobalFieldCollection*>(&mat_coll);
-    if (!mat_global_fc) {
-        throw RuntimeError("IsotropicStiffnessOperator3D material fields require GlobalFieldCollection");
-    }
-
-    // Validate ghost configuration for displacement/force fields
-    auto nb_ghosts_left = disp_global_fc->get_nb_ghosts_left();
-    auto nb_ghosts_right = disp_global_fc->get_nb_ghosts_right();
-    if (nb_ghosts_left[0] < 1 || nb_ghosts_left[1] < 1 || nb_ghosts_left[2] < 1) {
-        throw RuntimeError(
-            "IsotropicStiffnessOperator3D requires at least 1 ghost cell on the "
-            "left side of displacement/force fields");
-    }
-    if (nb_ghosts_right[0] < 1 || nb_ghosts_right[1] < 1 || nb_ghosts_right[2] < 1) {
-        throw RuntimeError(
-            "IsotropicStiffnessOperator3D requires at least 1 ghost cell on the "
-            "right side of displacement/force fields");
-    }
-
-    // Stencil requirements: 1 left, 1 right ghost needed
-    constexpr Index_t STENCIL_LEFT = 1;
-    constexpr Index_t STENCIL_RIGHT = 1;
-
-    // Compute computable region: total with ghosts minus stencil requirements
-    auto nb_with_ghosts = disp_global_fc->get_nb_subdomain_grid_pts_with_ghosts();
-    Index_t nnx = nb_with_ghosts[0] - STENCIL_LEFT - STENCIL_RIGHT;
-    Index_t nny = nb_with_ghosts[1] - STENCIL_LEFT - STENCIL_RIGHT;
-    Index_t nnz = nb_with_ghosts[2] - STENCIL_LEFT - STENCIL_RIGHT;
-
-    // Material field dimensions (computable region)
-    auto mat_nb_with_ghosts = mat_global_fc->get_nb_subdomain_grid_pts_with_ghosts();
-    Index_t nelx = mat_nb_with_ghosts[0] - STENCIL_LEFT - STENCIL_RIGHT;
-    Index_t nely = mat_nb_with_ghosts[1] - STENCIL_LEFT - STENCIL_RIGHT;
-    Index_t nelz = mat_nb_with_ghosts[2] - STENCIL_LEFT - STENCIL_RIGHT;
-
-    // Validate material field computable region matches node field
-    if (nelx != nnx || nely != nny || nelz != nnz) {
-        throw RuntimeError(
-            "IsotropicStiffnessOperator3D: material field computable region (" +
-            std::to_string(nelx) + ", " + std::to_string(nely) + ", " +
-            std::to_string(nelz) + ") must match node field computable region (" +
-            std::to_string(nnx) + ", " + std::to_string(nny) + ", " +
-            std::to_string(nnz) + ")");
-    }
-
-    // Validate material field ghost configuration
-    auto mat_nb_ghosts_left = mat_global_fc->get_nb_ghosts_left();
-    auto mat_nb_ghosts_right = mat_global_fc->get_nb_ghosts_right();
-    if (mat_nb_ghosts_left[0] < 1 || mat_nb_ghosts_left[1] < 1 || mat_nb_ghosts_left[2] < 1) {
-        throw RuntimeError("IsotropicStiffnessOperator3D requires at least "
-                           "1 ghost cell on the left side of material fields");
-    }
-    if (mat_nb_ghosts_right[0] < 1 || mat_nb_ghosts_right[1] < 1 || mat_nb_ghosts_right[2] < 1) {
-        throw RuntimeError("IsotropicStiffnessOperator3D requires at least "
-                           "1 ghost cell on the right side of material fields");
-    }
-
-    // Node dimensions (for displacement/force fields with ghosts)
-    Index_t nx = nb_with_ghosts[0];
-    Index_t ny = nb_with_ghosts[1];
-    Index_t nz = nb_with_ghosts[2];
-
-    // Material field dimensions with ghosts
-    Index_t mat_nx = mat_nb_with_ghosts[0];
-    Index_t mat_ny = mat_nb_with_ghosts[1];
-    Index_t mat_nz = mat_nb_with_ghosts[2];
-
-    // Offset to first computable node (based on stencil requirements)
-    Index_t ghost_offset_x = STENCIL_LEFT;
-    Index_t ghost_offset_y = STENCIL_LEFT;
-    Index_t ghost_offset_z = STENCIL_LEFT;
-    Index_t mat_ghost_offset_x = STENCIL_LEFT;
-    Index_t mat_ghost_offset_y = STENCIL_LEFT;
-    Index_t mat_ghost_offset_z = STENCIL_LEFT;
-
-    // GPU uses SoA layout: [d, x, y, z]
-    Index_t disp_stride_d = nx * ny * nz;
-    Index_t disp_stride_x = 1;
-    Index_t disp_stride_y = nx;
-    Index_t disp_stride_z = nx * ny;
-
-    Index_t mat_stride_x = 1;
-    Index_t mat_stride_y = mat_nx;
-    Index_t mat_stride_z = mat_nx * mat_ny;
-
-    Index_t force_stride_d = nx * ny * nz;
-    Index_t force_stride_x = 1;
-    Index_t force_stride_y = nx;
-    Index_t force_stride_z = nx * ny;
-
-    // Offset data pointers to account for left ghosts
-    Index_t disp_offset = ghost_offset_x * disp_stride_x +
-                          ghost_offset_y * disp_stride_y +
-                          ghost_offset_z * disp_stride_z;
-    Index_t force_offset = ghost_offset_x * force_stride_x +
-                           ghost_offset_y * force_stride_y +
-                           ghost_offset_z * force_stride_z;
-    Index_t mat_offset = mat_ghost_offset_x * mat_stride_x +
-                         mat_ghost_offset_y * mat_stride_y +
-                         mat_ghost_offset_z * mat_stride_z;
-
-    isotropic_stiffness_kernels::isotropic_stiffness_3d_hip(
-        displacement.view().data() + disp_offset,
-        lambda.view().data() + mat_offset,
-        mu.view().data() + mat_offset,
-        force.view().data() + force_offset,
-        nnx, nny, nnz,  // Number of interior nodes
-        nelx, nely, nelz,  // Number of elements (same as nodes)
-        disp_stride_x, disp_stride_y, disp_stride_z, disp_stride_d,
-        mat_stride_x, mat_stride_y, mat_stride_z,
-        force_stride_x, force_stride_y, force_stride_z, force_stride_d,
-        G_matrix.data(), V_matrix.data(),
-        alpha, increment);
-}
-
-#endif  // HIP
 
 }  // namespace muGrid
 

--- a/tests/python_decomposition_tests.py
+++ b/tests/python_decomposition_tests.py
@@ -2,6 +2,12 @@ import os
 
 import numpy as np
 import pytest
+from conftest import (
+    create_device,
+    get_array_module,
+    get_test_devices,
+    skip_if_gpu_unavailable,
+)
 from NuMPI import MPI
 from NuMPI.Testing.Assertions import assert_all_allclose
 from NuMPI.Testing.Subdivision import suggest_subdivisions
@@ -623,3 +629,55 @@ def test_collection_field_creation(comm, nb_subdivisions):
 
     # Verify ghost values are properly filled (all ones for constant field)
     np.testing.assert_array_almost_equal(field.sg, 1.0)
+
+
+@pytest.mark.parametrize("device", get_test_devices())
+def test_ghost_operations_devices(comm, device):
+    """Device communicate_ghosts and reduce_ghosts match the host results
+    (exercises the contiguous-staging device communication, including the
+    host-bounce fallback when MPI is not GPU-aware)."""
+    skip_if_gpu_unavailable(device)
+    xp = get_array_module(device)
+    nb_domain_grid_pts = [8, 6, 4]
+    subdivisions = [comm.size, 1, 1]
+    ghosts = [1, 1, 1]
+
+    buffers = {}
+    for dev in ("cpu", device):
+        dec = muGrid.CartesianDecomposition(
+            comm,
+            nb_domain_grid_pts,
+            subdivisions,
+            ghosts,
+            ghosts,
+            device=create_device(dev),
+        )
+        field = dec.real_field("ghost_ops")
+        x, y, z = dec.coords
+        values = 100 * x + 10 * y + z  # globally unique interior values
+        arr = xp.asarray(values) if dev != "cpu" else values
+
+        # communicate_ghosts: ghosts get filled from the periodic neighbors
+        field.pg[...] = -1.0
+        field.p[...] = arr
+        dec.communicate_ghosts(field)
+        comm_result = field.sg
+        comm_result = (
+            comm_result.get() if hasattr(comm_result, "get")
+            else np.array(comm_result)
+        )
+
+        # reduce_ghosts: ghost values accumulate onto the interior
+        field.pg[...] = 2.0
+        field.p[...] = arr
+        dec.reduce_ghosts(field)
+        reduce_result = field.sg
+        reduce_result = (
+            reduce_result.get() if hasattr(reduce_result, "get")
+            else np.array(reduce_result)
+        )
+
+        buffers[dev] = (comm_result, reduce_result)
+
+    np.testing.assert_allclose(buffers[device][0], buffers["cpu"][0])
+    np.testing.assert_allclose(buffers[device][1], buffers["cpu"][1])

--- a/tests/python_field_gpu_tests.py
+++ b/tests/python_field_gpu_tests.py
@@ -323,6 +323,10 @@ class CupyAllocatorTests(unittest.TestCase):
 
     def test_field_memory_from_cupy_pool(self):
         muGrid.use_cupy_allocator()
+        # Drop garbage from earlier tests so the pool baseline is stable
+        import gc
+
+        gc.collect()
         pool = cp.get_default_memory_pool()
         used_before = pool.used_bytes()
 
@@ -339,8 +343,6 @@ class CupyAllocatorTests(unittest.TestCase):
 
         # Destroying the collection returns the memory to the pool
         del field, fc
-        import gc
-
         gc.collect()
         self.assertEqual(pool.used_bytes(), used_before)
 

--- a/tests/python_field_gpu_tests.py
+++ b/tests/python_field_gpu_tests.py
@@ -314,5 +314,47 @@ class MixedHostDeviceTests(unittest.TestCase):
         self.assertIsInstance(device_arr, cp.ndarray)
 
 
+@unittest.skipUnless(GPU_AVAILABLE and HAS_CUPY, "GPU backend or CuPy not available")
+class CupyAllocatorTests(unittest.TestCase):
+    """muGrid device allocations routed through cupy's memory pool."""
+
+    def tearDown(self):
+        muGrid.clear_device_allocator()
+
+    def test_field_memory_from_cupy_pool(self):
+        muGrid.use_cupy_allocator()
+        pool = cp.get_default_memory_pool()
+        used_before = pool.used_bytes()
+
+        fc = muGrid.GlobalFieldCollection([16, 16], device=muGrid.Device.gpu())
+        field = fc.real_field("pooled")
+        # The field's buffer must have been drawn from cupy's pool
+        self.assertGreaterEqual(
+            pool.used_bytes() - used_before, 16 * 16 * 8
+        )
+
+        # The field is fully functional
+        field.s[...] = 3.0
+        self.assertAlmostEqual(float(cp.sum(field.s)), 3.0 * 16 * 16)
+
+        # Destroying the collection returns the memory to the pool
+        del field, fc
+        import gc
+
+        gc.collect()
+        self.assertEqual(pool.used_bytes(), used_before)
+
+    def test_clear_restores_default_allocator(self):
+        muGrid.use_cupy_allocator()
+        pool = cp.get_default_memory_pool()
+        muGrid.clear_device_allocator()
+
+        used_before = pool.used_bytes()
+        fc = muGrid.GlobalFieldCollection([8, 8], device=muGrid.Device.gpu())
+        fc.real_field("unpooled")
+        # Allocation no longer comes from the pool
+        self.assertEqual(pool.used_bytes(), used_before)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/python_linalg_host_tests.py
+++ b/tests/python_linalg_host_tests.py
@@ -60,10 +60,10 @@ import pytest
 import muGrid
 from muGrid import linalg
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
 
 def _collection(nb_grid_pts, nb_ghosts=1):
     g = (nb_ghosts,) * len(nb_grid_pts)
@@ -463,6 +463,54 @@ class TestGPUSubPoints:
         linalg.axpy(alpha, gx, gy)
         # Interior norm of the updated y must match between CPU and GPU.
         assert linalg.norm_sq(cy) == pytest.approx(linalg.norm_sq(gy), rel=1e-10)
+
+
+class TestFieldScal:
+    """scal with a field-valued alpha: broadcast and elementwise modes, on
+    both storage orders (host collections default to AoS; SoA is what GPU
+    collections use and is also constructible on the host)."""
+
+    @pytest.mark.parametrize(
+        "storage_order",
+        [muGrid.StorageOrder.ArrayOfStructures,
+         muGrid.StorageOrder.StructureOfArrays],
+    )
+    @pytest.mark.parametrize("complex_", [False, True])
+    @pytest.mark.parametrize("nb_alpha_components", [1, 2])
+    def test_scal_field_alpha(self, rng, storage_order, complex_,
+                              nb_alpha_components):
+        fc = muGrid.GlobalFieldCollection(
+            [7, 5], storage_order=storage_order
+        )
+        x = _make(fc, "x", components=(2,), complex_=complex_)
+        alpha = fc.real_field(
+            "alpha", () if nb_alpha_components == 1 else (2,)
+        )
+        x_before = _fill(x, rng, complex_=complex_)
+        alpha_values = _fill(alpha, rng)
+
+        linalg.scal(alpha, x)
+
+        # numpy reference: broadcast a single-component alpha over the
+        # components of x, apply a matching alpha elementwise
+        expected = x_before * alpha_values
+        np.testing.assert_allclose(np.array(x.sg), expected, atol=1e-14)
+
+    def test_scal_field_alpha_validation(self, rng):
+        fc = muGrid.GlobalFieldCollection([7, 5])
+        other = muGrid.GlobalFieldCollection([7, 5])
+        x = _make(fc, "x", components=(2,))
+        _fill(x, rng)
+
+        # alpha from a different collection is rejected
+        alpha_other = other.real_field("alpha")
+        with pytest.raises(RuntimeError, match="same collection"):
+            linalg.scal(alpha_other, x)
+
+        # component-count mismatch (neither 1 nor x's count) is rejected
+        alpha_bad = fc.real_field("alpha3", (3,))
+        with pytest.raises(RuntimeError, match="components"):
+            linalg.scal(alpha_bad, x)
 
 
 if __name__ == "__main__":

--- a/tests/python_preconditioner_tests.py
+++ b/tests/python_preconditioner_tests.py
@@ -413,5 +413,85 @@ def test_jacobi_screened_poisson_devices(comm, device):
     assert iterations_jacobi < iterations_plain / 2
 
 
+@pytest.mark.parametrize("device", get_test_devices())
+def test_fourier_preconditioned_poisson_devices(comm, device):
+    """The spectral preconditioner runs on the device the solver fields
+    live on (exercises the complex field-valued linalg.scal and the
+    device FFT path) and still acts as a direct solve."""
+    skip_if_gpu_unavailable(device)
+    xp = get_array_module(device)
+    nb_grid_pts = (32, 32)
+    grid_spacing = 1 / nb_grid_pts[0]
+
+    laplace = muGrid.LaplaceOperator(2, -1.0 / grid_spacing**2)
+    engine = muGrid.FFTEngine(
+        nb_grid_pts, comm, ghosts=laplace, device=create_device(device)
+    )
+    prec = FourierPreconditioner(
+        engine, inverse_fd_laplace_kernel(grid_spacing)
+    )
+
+    def hessp(x_field, Ax_field):
+        engine.communicate_ghosts(x_field)
+        laplace.apply(x_field, Ax_field)
+
+    rhs = engine.real_space_field("rhs")
+    solution = engine.real_space_field("solution")
+    ox, oy = engine.subdomain_locations
+    lx, ly = engine.nb_subdomain_grid_pts
+    rhs.p[...] = xp.asarray(global_rhs(nb_grid_pts)[ox : ox + lx, oy : oy + ly])
+
+    iterations = []
+    conjugate_gradients(
+        comm,
+        engine.real_space_collection,
+        rhs,
+        solution,
+        hessp=hessp,
+        prec=prec,
+        rtol=1e-8,
+        maxiter=200,
+        callback=lambda it, state: iterations.append(it),
+    )
+    assert max(iterations) <= 3
+    np.testing.assert_allclose(
+        to_host(solution.p), local_reference(engine), atol=1e-10
+    )
+
+    # The spectral kernel broadcasts over components on the device, too:
+    # identical per-component inputs give identical per-component outputs.
+    r1 = engine.real_space_field("residual")
+    z1 = engine.real_space_field("preconditioned")
+    r2 = engine.real_space_field("residual2", components=(2,))
+    z2 = engine.real_space_field("preconditioned2", components=(2,))
+    r1.p[...] = xp.asarray(np.sin(2 * np.pi * np.array(engine.coords)[0]))
+    r2.p[0] = r1.p
+    r2.p[1] = r1.p
+    prec(r1, z1)
+    prec(r2, z2)
+    np.testing.assert_allclose(to_host(z2.p[0]), to_host(z1.p), atol=1e-12)
+    np.testing.assert_allclose(to_host(z2.p[1]), to_host(z1.p), atol=1e-12)
+
+
+@pytest.mark.parametrize("device", get_test_devices())
+def test_jacobi_broadcast_multicomponent(comm, device):
+    """A spatial-only diagonal broadcasts over the components of a
+    multi-component residual."""
+    skip_if_gpu_unavailable(device)
+    xp = get_array_module(device)
+    engine = muGrid.FFTEngine((16, 16), comm, device=create_device(device))
+    x, y = engine.coords
+
+    r = engine.real_space_field("residual", components=(2,))
+    z = engine.real_space_field("preconditioned", components=(2,))
+    r_values = np.stack([np.sin(2 * np.pi * x), np.cos(2 * np.pi * y)])
+    r.p[...] = xp.asarray(r_values)
+
+    diag = 1 + x + 2 * y  # spatial-only: shared across components
+    prec = JacobiPreconditioner(diag)
+    prec(r, z)
+    np.testing.assert_allclose(to_host(z.p), r_values / diag, atol=1e-15)
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/python_preconditioner_tests.py
+++ b/tests/python_preconditioner_tests.py
@@ -5,6 +5,12 @@ FFT (spectral) preconditioning of a finite-difference Laplace solve.
 
 import numpy as np
 import pytest
+from conftest import (
+    create_device,
+    get_array_module,
+    get_test_devices,
+    skip_if_gpu_unavailable,
+)
 
 import muGrid
 from muGrid.Preconditioners import (
@@ -285,6 +291,125 @@ def test_jacobi_preconditioned_screened_poisson(comm):
     # Both converged to the same solution ...
     np.testing.assert_allclose(solution_jacobi.p, solution_plain, atol=1e-7)
     # ... but Jacobi equilibrates the heterogeneous coefficient
+    assert iterations_jacobi < iterations_plain / 2
+
+
+def to_host(array):
+    """Return a host copy of a numpy or cupy array."""
+    return array.get() if hasattr(array, "get") else np.array(array)
+
+
+@pytest.mark.parametrize("device", get_test_devices())
+def test_jacobi_apply_devices(comm, device):
+    """JacobiPreconditioner applies D^-1 through field kernels on the
+    device the solver fields live on (this exercises the field-valued
+    linalg.scal on host and GPU)."""
+    skip_if_gpu_unavailable(device)
+    xp = get_array_module(device)
+    engine = muGrid.FFTEngine((16, 16), comm, device=create_device(device))
+    x, y = engine.coords
+
+    diag = 1 + x + 2 * y  # spatial-only diagonal, host values
+
+    r = engine.real_space_field("residual")
+    z = engine.real_space_field("preconditioned")
+    r_values = np.sin(2 * np.pi * x)
+    r.p[...] = xp.asarray(r_values)
+
+    prec = JacobiPreconditioner(diag)
+    prec(r, z)
+    np.testing.assert_allclose(to_host(z.p), r_values / diag, atol=1e-15)
+
+    # Scalar diagonal stays on the device, too
+    JacobiPreconditioner(2.0)(r, z)
+    np.testing.assert_allclose(to_host(z.p), r_values / 2, atol=1e-15)
+
+
+@pytest.mark.parametrize("device", get_test_devices())
+def test_jacobi_apply_per_component(comm, device):
+    """A per-component diagonal is applied elementwise (no broadcast)."""
+    skip_if_gpu_unavailable(device)
+    xp = get_array_module(device)
+    engine = muGrid.FFTEngine((16, 16), comm, device=create_device(device))
+    x, y = engine.coords
+
+    r = engine.real_space_field("residual", components=(2,))
+    z = engine.real_space_field("preconditioned", components=(2,))
+    r_values = np.stack([np.sin(2 * np.pi * x), np.cos(2 * np.pi * y)])
+    r.p[...] = xp.asarray(r_values)
+
+    diag = np.stack([1 + x, 2 + y]).reshape(r.s.shape)
+    prec = JacobiPreconditioner(diag)
+    prec(r, z)
+    np.testing.assert_allclose(
+        to_host(z.s), r_values.reshape(r.s.shape) / diag, atol=1e-15
+    )
+
+
+@pytest.mark.parametrize("device", get_test_devices())
+def test_jacobi_screened_poisson_devices(comm, device):
+    """Jacobi-preconditioned CG for the heterogeneous screened Poisson
+    problem runs end-to-end on the device and reduces iterations."""
+    skip_if_gpu_unavailable(device)
+    xp = get_array_module(device)
+    nb_grid_pts = (32, 32)
+    grid_spacing = 1 / nb_grid_pts[0]
+
+    # Positive-definite -Laplacian/h^2 via the hardcoded stencil operator
+    laplace = muGrid.LaplaceOperator(2, -1.0 / grid_spacing**2)
+
+    def make_device_engine():
+        return muGrid.FFTEngine(
+            nb_grid_pts, comm, ghosts=laplace, device=create_device(device)
+        )
+
+    def solve(prec):
+        engine = make_device_engine()
+        x, y = engine.coords
+        c = xp.asarray(
+            1 + 1e6 * (np.sin(2 * np.pi * x) * np.sin(2 * np.pi * y)) ** 2
+        )
+
+        def hessp(x_field, Ax_field):
+            engine.communicate_ghosts(x_field)
+            laplace.apply(x_field, Ax_field)
+            Ax_field.s[...] += c * x_field.s
+
+        rhs = engine.real_space_field("rhs")
+        solution = engine.real_space_field("solution")
+        ox, oy = engine.subdomain_locations
+        lx, ly = engine.nb_subdomain_grid_pts
+        rhs.p[...] = xp.asarray(
+            global_rhs(nb_grid_pts)[ox : ox + lx, oy : oy + ly]
+        )
+        iterations = []
+        conjugate_gradients(
+            comm,
+            engine.real_space_collection,
+            rhs,
+            solution,
+            hessp=hessp,
+            prec=prec,
+            rtol=1e-8,
+            maxiter=1000,
+            callback=lambda it, state: iterations.append(it),
+        )
+        return to_host(solution.p), max(iterations), engine
+
+    solution_plain, iterations_plain, _ = solve(prec=None)
+
+    engine = make_device_engine()
+    x, y = engine.coords
+    diag = (
+        4 / grid_spacing**2
+        + 1
+        + 1e6 * (np.sin(2 * np.pi * x) * np.sin(2 * np.pi * y)) ** 2
+    )
+    solution_jacobi, iterations_jacobi, _ = solve(
+        prec=JacobiPreconditioner(diag)
+    )
+
+    np.testing.assert_allclose(solution_jacobi, solution_plain, atol=1e-7)
     assert iterations_jacobi < iterations_plain / 2
 
 


### PR DESCRIPTION
This PR adds packing of communication buffers rather than using strided field in MPI. The reason is that most MPI implementation do not handle non-contiguous buffers gracefully on GPUs.