### PR TITLE
ENH: NetCDF I/O directly from device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,27 @@ Change log for µGrid
 Unreleased
 ----------
 
+- ENH: NetCDF I/O now supports device-resident (GPU) fields directly. On
+  discrete GPUs the field is staged through a temporary host buffer: a host
+  (array-of-structures) mirror collection with identical topology, populated
+  via `deep_copy` (host<->device transfer plus AoS<->SoA conversion) before a
+  write and after a read, so the existing host I/O path is reused unchanged.
+  Device-resident state fields are unsupported and fail loudly.
+- ENH: On unified-memory devices (integrated APUs such as the AMD MI300A) the
+  staging buffer is skipped entirely: the host-coherent device allocation is
+  written and read in place (zero-copy). Eligibility is detected at runtime via
+  `Device::is_host_accessible()` (cached `cudaDeviceProp`/`hipDeviceProp`
+  `integrated` query) and exposed through `Field::is_host_accessible()`;
+  discrete GPUs keep using the host mirror.
+- API: New type-erased `Field::deep_copy_from(const Field &)` dispatches on the
+  source field's memory space; new `Field::is_host_accessible()`; new
+  `GlobalFieldCollection::get_empty_clone(Device, StorageOrder)` and
+  `LocalFieldCollection::get_empty_clone(name, Device)` for cloning a
+  collection onto a different device / storage order
+- BUG: `NetCDFVarField::get_buf` now computes the ghost-skip offset from the
+  field's storage order (array-of-structures vs structure-of-arrays) instead of
+  assuming array-of-structures, so structure-of-arrays fields with ghosts are
+  written and read at the correct offset
 - ENH: Complex GPU linalg is now implemented. The `Complex` device
   specialisations of `vecdot`, `norm_sq`, `axpy`, `scal`, `axpby`, `copy` and
   `axpy_norm_sq` (previously throwing stubs) now run on CUDA/HIP, processing the

--- a/src/libmugrid/collection/field_collection_global.cc
+++ b/src/libmugrid/collection/field_collection_global.cc
@@ -269,11 +269,19 @@ namespace muGrid {
 
     /* ---------------------------------------------------------------------- */
     GlobalFieldCollection GlobalFieldCollection::get_empty_clone() const {
+        return this->get_empty_clone(this->get_device(),
+                                     this->get_storage_order());
+    }
+
+    /* ---------------------------------------------------------------------- */
+    GlobalFieldCollection
+    GlobalFieldCollection::get_empty_clone(Device device,
+                                           StorageOrder storage_order) const {
         GlobalFieldCollection ret_val{
             this->get_spatial_dim(),
             this->nb_sub_pts,
-            this->get_storage_order(),
-            this->get_device()
+            storage_order,
+            device
         };
         // Forward the ghost specification and pixel strides so the clone has
         // an identical layout (interior region, ghost counts and memory order).

--- a/src/libmugrid/collection/field_collection_global.hh
+++ b/src/libmugrid/collection/field_collection_global.hh
@@ -253,6 +253,15 @@ namespace muGrid {
          */
         GlobalFieldCollection get_empty_clone() const;
 
+        /**
+         * obtain a new field collection with the same domain and pixels but a
+         * caller-specified memory device and component storage order. This is
+         * used, e.g., to build a host-resident (AoS) staging mirror of a
+         * device-resident collection for file I/O.
+         */
+        GlobalFieldCollection
+        get_empty_clone(Device device, StorageOrder storage_order) const;
+
         //! return shape of the pixels
         Shape_t get_pixels_shape() const override;
 

--- a/src/libmugrid/collection/field_collection_local.cc
+++ b/src/libmugrid/collection/field_collection_local.cc
@@ -80,9 +80,15 @@ namespace muGrid {
     /* ---------------------------------------------------------------------- */
     LocalFieldCollection
     LocalFieldCollection::get_empty_clone(const std::string & new_name) const {
+        return this->get_empty_clone(new_name, this->get_device());
+    }
+
+    /* ---------------------------------------------------------------------- */
+    LocalFieldCollection
+    LocalFieldCollection::get_empty_clone(const std::string & new_name,
+                                          Device device) const {
         LocalFieldCollection ret_val{this->get_spatial_dim(), new_name,
-                                     this->nb_sub_pts,
-                                     this->get_device()};
+                                     this->nb_sub_pts, device};
         for (const auto & pixel_id : this->get_pixel_indices()) {
             ret_val.add_pixel(pixel_id);
         }

--- a/src/libmugrid/collection/field_collection_local.hh
+++ b/src/libmugrid/collection/field_collection_local.hh
@@ -124,6 +124,15 @@ namespace muGrid {
         get_empty_clone(const std::string & new_name) const;
 
         /**
+         * obtain a new field collection with the same domain and pixels, a
+         * given new name and a caller-specified memory device. This is used,
+         * e.g., to build a host-resident staging mirror of a device-resident
+         * collection for file I/O.
+         */
+        LocalFieldCollection get_empty_clone(const std::string & new_name,
+                                             Device device) const;
+
+        /**
          * obtain a new field collection with the same domain and pixels and the
          * same name
          */

--- a/src/libmugrid/field/field.hh
+++ b/src/libmugrid/field/field.hh
@@ -360,6 +360,16 @@ namespace muGrid {
         virtual bool is_on_device() const = 0;
 
         /**
+         * Check whether this field's data can be dereferenced directly by the
+         * host CPU. Always true for host-resident fields; true for
+         * device-resident fields only on unified-memory / integrated devices
+         * (e.g. an APU), where the device allocation is host-coherent. When
+         * true, the raw pointer from get_void_data_ptr(false) may be passed to
+         * host-side libraries (such as NetCDF) without a staging copy.
+         */
+        virtual bool is_host_accessible() const = 0;
+
+        /**
          * Get DLPack device type for this field's memory space.
          * Returns kDLCPU=1, kDLCUDA=2, kDLROCm=10, etc.
          */

--- a/src/libmugrid/field/field.hh
+++ b/src/libmugrid/field/field.hh
@@ -344,6 +344,16 @@ namespace muGrid {
         Unit get_physical_unit() const;
 
         /**
+         * Deep copy the field values from another field, performing a
+         * host<->device transfer and a storage-order (AoS<->SoA) conversion as
+         * needed. The source field must have the same scalar type and a
+         * compatible logical layout (same number of buffer entries). This is a
+         * type-erased entry point: the concrete implementation dispatches on
+         * the source field's memory space.
+         */
+        virtual void deep_copy_from(const Field & src) = 0;
+
+        /**
          * Check if field resides on device (GPU) memory.
          * Returns true for CUDA and ROCm/HIP device memory spaces.
          */

--- a/src/libmugrid/field/field_typed.hh
+++ b/src/libmugrid/field/field_typed.hh
@@ -352,6 +352,20 @@ namespace muGrid {
     }
 
     /**
+     * Check whether this field's data is directly host-accessible. Host-space
+     * fields always are; device-space fields are only on unified-memory /
+     * integrated devices, which is queried at runtime from the collection's
+     * Device.
+     */
+    bool is_host_accessible() const final {
+      if constexpr (is_host_space_v<MemorySpace>) {
+        return true;
+      } else {
+        return this->get_collection().get_device().is_host_accessible();
+      }
+    }
+
+    /**
      * Get DLPack device type for this field's memory space.
      */
     int get_dlpack_device_type() const final {

--- a/src/libmugrid/field/field_typed.hh
+++ b/src/libmugrid/field/field_typed.hh
@@ -318,6 +318,32 @@ namespace muGrid {
     void deep_copy_from(const TypedFieldBase<T, OtherSpace> & src);
 
     /**
+     * Type-erased deep copy: dispatches on the source field's memory space
+     * and forwards to the typed `deep_copy_from` above. Performs a
+     * host<->device transfer and an AoS<->SoA conversion as required.
+     */
+    void deep_copy_from(const Field & src) final {
+      if (src.get_type_descriptor() != this->get_type_descriptor()) {
+        throw FieldError(
+            "deep_copy_from: scalar type mismatch between source and "
+            "destination fields");
+      }
+      if (src.is_on_device()) {
+#if defined(MUGRID_ENABLE_CUDA) || defined(MUGRID_ENABLE_HIP)
+        this->deep_copy_from(
+            dynamic_cast<const TypedFieldBase<T, DefaultDeviceSpace> &>(src));
+#else
+        throw FieldError(
+            "deep_copy_from: source field reports device residency but this "
+            "build has no GPU support");
+#endif
+      } else {
+        this->deep_copy_from(
+            dynamic_cast<const TypedFieldBase<T, HostSpace> &>(src));
+      }
+    }
+
+    /**
      * Check if field resides on device (GPU) memory.
      * Implementation uses compile-time type trait.
      */

--- a/src/libmugrid/io/file_io_netcdf.cc
+++ b/src/libmugrid/io/file_io_netcdf.cc
@@ -2111,8 +2111,9 @@ namespace muGrid {
         field.get_storage_order() == StorageOrder::ArrayOfStructures
             ? field.get_nb_dof_per_pixel()
             : Index_t{1}};
-    const Index_t byte_offset{pixel_offset * dofs_per_pixel *
-                              field.get_element_size_in_bytes()};
+    const Index_t byte_offset{
+        pixel_offset * dofs_per_pixel *
+        static_cast<Index_t>(field.get_element_size_in_bytes())};
 
     return buf_ptr + byte_offset;
   }

--- a/src/libmugrid/io/file_io_netcdf.cc
+++ b/src/libmugrid/io/file_io_netcdf.cc
@@ -1971,9 +1971,111 @@ namespace muGrid {
   }
 
   /* ---------------------------------------------------------------------- */
+  namespace {
+    //! Register, in `coll`, a host field matching the prototype `proto`
+    //! (same name, scalar type, component shape, sub-division tag and unit).
+    muGrid::Field & register_mirror_field(muGrid::FieldCollection & coll,
+                                          const muGrid::Field & proto) {
+      const std::string name{proto.get_name()};
+      const Shape_t shape{proto.get_components_shape()};
+      const std::string tag{proto.get_sub_division_tag()};
+      const muGrid::Unit unit{proto.get_physical_unit()};
+      switch (proto.get_type_descriptor()) {
+      case muGrid::TypeDescriptor::Real:
+        return coll.register_field<muGrid::Real>(name, shape, tag, unit);
+      case muGrid::TypeDescriptor::Complex:
+        return coll.register_field<muGrid::Complex>(name, shape, tag, unit);
+      case muGrid::TypeDescriptor::Int:
+        return coll.register_field<muGrid::Int>(name, shape, tag, unit);
+      case muGrid::TypeDescriptor::Uint:
+        return coll.register_field<muGrid::Uint>(name, shape, tag, unit);
+      case muGrid::TypeDescriptor::Index:
+        return coll.register_field<muGrid::Index_t>(name, shape, tag, unit);
+      default:
+        throw FileIOError(
+            "Cannot create a host staging mirror for field '" + name +
+            "': unsupported scalar type.");
+      }
+    }
+  }  // namespace
+
+  /* ---------------------------------------------------------------------- */
+  muGrid::Field & NetCDFVarBase::get_host_mirror() const {
+    if (!this->supports_device_staging()) {
+      throw FileIOError(
+          "Reading or writing a device-resident state field ('" +
+          this->get_name() +
+          "') via NetCDF is not supported. Copy the state field to a "
+          "host-resident field collection before performing file I/O.");
+    }
+    if (this->host_mirror_field == nullptr) {
+      const muGrid::Field & device_field{this->get_field()};
+      const muGrid::FieldCollection & device_coll{
+          device_field.get_collection()};
+
+      // Build a host-resident, array-of-structures clone of the collection so
+      // that the existing host I/O path (buffer offset, index map, strides)
+      // remains valid without modification. The subsequent deep_copy then
+      // performs the SoA->AoS conversion and the device->host transfer.
+      if (auto * gfc = dynamic_cast<const muGrid::GlobalFieldCollection *>(
+              &device_coll)) {
+        this->host_mirror_collection =
+            std::make_unique<muGrid::GlobalFieldCollection>(
+                gfc->get_empty_clone(muGrid::Device::cpu(),
+                                     muGrid::StorageOrder::ArrayOfStructures));
+      } else if (auto * lfc =
+                     dynamic_cast<const muGrid::LocalFieldCollection *>(
+                         &device_coll)) {
+        this->host_mirror_collection =
+            std::make_unique<muGrid::LocalFieldCollection>(
+                lfc->get_empty_clone(lfc->get_name(), muGrid::Device::cpu()));
+      } else {
+        throw FileIOError(
+            "Cannot create a host staging mirror: unknown field collection "
+            "type.");
+      }
+
+      this->host_mirror_field =
+          &register_mirror_field(*this->host_mirror_collection, device_field);
+    }
+    return *this->host_mirror_field;
+  }
+
+  /* ---------------------------------------------------------------------- */
+  const muGrid::Field & NetCDFVarBase::get_io_field() const {
+    const muGrid::Field & field{this->get_field()};
+    if (field.is_on_device()) {
+      return this->get_host_mirror();
+    }
+    return field;
+  }
+
+  /* ---------------------------------------------------------------------- */
+  void NetCDFVarBase::stage_to_host() const {
+    const muGrid::Field & field{this->get_field()};
+    if (field.is_on_device()) {
+      this->get_host_mirror().deep_copy_from(field);
+    }
+  }
+
+  /* ---------------------------------------------------------------------- */
+  void NetCDFVarBase::stage_to_device() const {
+    const muGrid::Field & field{this->get_field()};
+    if (field.is_on_device()) {
+      // get_field() is const, but the underlying field is mutable (it is held
+      // as a non-const reference by the variable); we need write access to
+      // push the data that was just read back to the device.
+      const_cast<muGrid::Field &>(field).deep_copy_from(
+          this->get_host_mirror());
+    }
+  }
+
+  /* ---------------------------------------------------------------------- */
   void * NetCDFVarBase::get_buf() const {
-    // Default assert_host_memory=true ensures device fields throw an error
-    const Field & field{this->get_field()};
+    // For device-resident fields this resolves to the host staging mirror; for
+    // host-resident fields it is the field itself (assert_host_memory=true
+    // still guards against any unexpected device pointer).
+    const Field & field{this->get_io_field()};
     char * buf_ptr{static_cast<char *>(field.get_void_data_ptr())};
 
     // Compute byte offset to skip ghost buffer and access interior data
@@ -2401,6 +2503,10 @@ namespace muGrid {
     // check if frame is correct and compute positive frame value
     Index_t frame{FileIONetCDF::handle_frame(frame_index, tot_nb_frames)};
 
+    // For device-resident fields, copy the data into the host staging mirror
+    // before issuing the (host-based) NetCDF write. No-op for host fields.
+    this->stage_to_host();
+
     int status{};
     if (this->get_validity_domain() ==
         muGrid::FieldCollection::ValidityDomain::Global) {
@@ -2604,6 +2710,10 @@ namespace muGrid {
       }
 #endif  // WITH_MPI
     }
+
+    // For device-resident fields, the data was read into the host staging
+    // mirror; copy it back to the device. No-op for host fields.
+    this->stage_to_device();
   }
 
   /* ---------------------------------------------------------------------- */
@@ -2788,15 +2898,18 @@ namespace muGrid {
 
   /* ---------------------------------------------------------------------- */
   std::vector<IODiff_t> NetCDFVarField::get_nc_imap_global() const {
-    // construct imap from field strides
+    // construct imap from field strides. The strides describe the in-memory
+    // layout and must therefore be taken from the field that actually backs
+    // the I/O buffer (the host staging mirror for device-resident fields).
+    const muGrid::Field & field{this->get_io_field()};
     IterUnit iter_type{muGrid::IterUnit::SubPt};
-    if (this->get_field().get_nb_components() == 1) {
+    if (field.get_nb_components() == 1) {
       iter_type = muGrid::IterUnit::Pixel;
     }
     std::vector<IODiff_t> imap_strides{
-        this->get_field().get_nb_pixels_without_ghosts() *
-        this->get_field().get_nb_dof_per_pixel()};  // imap of frame (nb_dofs)
-    auto strides_wrong_type{this->get_field().get_strides(iter_type)};
+        field.get_nb_pixels_without_ghosts() *
+        field.get_nb_dof_per_pixel()};  // imap of frame (nb_dofs)
+    auto strides_wrong_type{field.get_strides(iter_type)};
     std::vector<IODiff_t> strides(strides_wrong_type.begin(),
                                   strides_wrong_type.end());
     imap_strides.insert(imap_strides.end(), strides.begin(), strides.end());
@@ -2816,16 +2929,18 @@ namespace muGrid {
 
   /* ---------------------------------------------------------------------- */
   std::vector<IODiff_t> NetCDFVarField::get_nc_imap_local() const {
-    // construc imap from field strides
+    // construc imap from field strides. The strides describe the in-memory
+    // layout and must therefore be taken from the field that actually backs
+    // the I/O buffer (the host staging mirror for device-resident fields).
+    const muGrid::Field & field{this->get_io_field()};
     IterUnit iter_type{muGrid::IterUnit::SubPt};
-    if (this->get_field().get_nb_components() == 1) {
+    if (field.get_nb_components() == 1) {
       iter_type = muGrid::IterUnit::Pixel;
     }
     std::vector<IODiff_t> imap_strides{
-        this->get_field().get_nb_pixels_without_ghosts() *
-        this->get_field()
-            .get_nb_dof_per_pixel()};  // imap of frame (nb_pix*nb_dofs)
-    auto strides_wrong_type{this->get_field().get_strides(iter_type)};
+        field.get_nb_pixels_without_ghosts() *
+        field.get_nb_dof_per_pixel()};  // imap of frame (nb_pix*nb_dofs)
+    auto strides_wrong_type{field.get_strides(iter_type)};
     std::vector<IODiff_t> strides{strides_wrong_type.begin(),
                                   strides_wrong_type.end()};
     imap_strides.insert(imap_strides.end(), strides.begin(), strides.end());

--- a/src/libmugrid/io/file_io_netcdf.cc
+++ b/src/libmugrid/io/file_io_netcdf.cc
@@ -2000,7 +2000,11 @@ namespace muGrid {
   }  // namespace
 
   /* ---------------------------------------------------------------------- */
-  muGrid::Field & NetCDFVarBase::get_host_mirror() const {
+  bool NetCDFVarBase::needs_mirror() const {
+    const muGrid::Field & field{this->get_field()};
+    if (!field.is_on_device()) {
+      return false;
+    }
     if (!this->supports_device_staging()) {
       throw FileIOError(
           "Reading or writing a device-resident state field ('" +
@@ -2008,6 +2012,13 @@ namespace muGrid {
           "') via NetCDF is not supported. Copy the state field to a "
           "host-resident field collection before performing file I/O.");
     }
+    // On a unified-memory device the field is dereferenceable by the host and
+    // is written/read in place; otherwise a host staging mirror is needed.
+    return !field.is_host_accessible();
+  }
+
+  /* ---------------------------------------------------------------------- */
+  muGrid::Field & NetCDFVarBase::get_host_mirror() const {
     if (this->host_mirror_field == nullptr) {
       const muGrid::Field & device_field{this->get_field()};
       const muGrid::FieldCollection & device_coll{
@@ -2043,51 +2054,65 @@ namespace muGrid {
 
   /* ---------------------------------------------------------------------- */
   const muGrid::Field & NetCDFVarBase::get_io_field() const {
-    const muGrid::Field & field{this->get_field()};
-    if (field.is_on_device()) {
+    if (this->needs_mirror()) {
       return this->get_host_mirror();
     }
-    return field;
+    // Host-resident or host-accessible (unified-memory) device field: operate
+    // on the field directly, no staging buffer.
+    return this->get_field();
   }
 
   /* ---------------------------------------------------------------------- */
   void NetCDFVarBase::stage_to_host() const {
-    const muGrid::Field & field{this->get_field()};
-    if (field.is_on_device()) {
-      this->get_host_mirror().deep_copy_from(field);
+    if (this->needs_mirror()) {
+      this->get_host_mirror().deep_copy_from(this->get_field());
     }
   }
 
   /* ---------------------------------------------------------------------- */
   void NetCDFVarBase::stage_to_device() const {
-    const muGrid::Field & field{this->get_field()};
-    if (field.is_on_device()) {
+    if (this->needs_mirror()) {
       // get_field() is const, but the underlying field is mutable (it is held
       // as a non-const reference by the variable); we need write access to
       // push the data that was just read back to the device.
-      const_cast<muGrid::Field &>(field).deep_copy_from(
-          this->get_host_mirror());
+      const_cast<muGrid::Field &>(this->get_field())
+          .deep_copy_from(this->get_host_mirror());
     }
   }
 
   /* ---------------------------------------------------------------------- */
   void * NetCDFVarBase::get_buf() const {
-    // For device-resident fields this resolves to the host staging mirror; for
-    // host-resident fields it is the field itself (assert_host_memory=true
-    // still guards against any unexpected device pointer).
+    // For a non-host-accessible device field this resolves to the host staging
+    // mirror; otherwise it is the field itself (a host field, or a
+    // host-accessible unified-memory device field written/read in place).
     const Field & field{this->get_io_field()};
-    char * buf_ptr{static_cast<char *>(field.get_void_data_ptr())};
+    // Host-resident fields keep assert_host_memory=true as a safety net. A
+    // host-accessible device field (unified memory) is dereferenceable from
+    // the CPU, so its raw device pointer may be used directly.
+    char * buf_ptr{static_cast<char *>(
+        field.get_void_data_ptr(/*assert_host_memory=*/!field.is_on_device()))};
 
-    // Compute byte offset to skip ghost buffer and access interior data
-    // The offset is computed using pixel offsets and strides
+    // Linear pixel offset (in pixels) from the buffer start to the first
+    // interior (non-ghost) pixel.
     auto pixel_offsets{field.get_pixels_offset_without_ghosts()};
     auto pixel_strides{field.get_collection().get_pixels_strides(1)};
-    Index_t byte_offset{0};
+    Index_t pixel_offset{0};
     for (size_t i = 0; i < pixel_offsets.size(); ++i) {
-      byte_offset += pixel_offsets[i] * pixel_strides[i];
+      pixel_offset += pixel_offsets[i] * pixel_strides[i];
     }
-    // Multiply by degrees of freedom per pixel and element size
-    byte_offset *= field.get_nb_dof_per_pixel() * field.get_element_size_in_bytes();
+    // Convert to a scalar offset to the first interior element. In
+    // array-of-structures storage each pixel occupies nb_dof_per_pixel
+    // contiguous scalars, so the interior begins nb_dof_per_pixel * pixel
+    // offset in. In structure-of-arrays storage consecutive pixels of a
+    // component are unit-strided, so the interior of component 0 begins just
+    // pixel_offset in (the index map's component stride, which equals the
+    // buffer pixel count, then jumps between component planes).
+    const Index_t dofs_per_pixel{
+        field.get_storage_order() == StorageOrder::ArrayOfStructures
+            ? field.get_nb_dof_per_pixel()
+            : Index_t{1}};
+    const Index_t byte_offset{pixel_offset * dofs_per_pixel *
+                              field.get_element_size_in_bytes()};
 
     return buf_ptr + byte_offset;
   }

--- a/src/libmugrid/io/file_io_netcdf.hh
+++ b/src/libmugrid/io/file_io_netcdf.hh
@@ -819,6 +819,14 @@ namespace muGrid {
     //! taken from this field.
     const muGrid::Field & get_io_field() const;
 
+    //! whether a host staging mirror (and host<->device copy) is required for
+    //! this variable: true only for a device-resident field that is *not*
+    //! directly host-accessible. A device-resident field on a unified-memory
+    //! device is written/read in place (zero-copy), and host-resident fields
+    //! never need a mirror. Throws for unsupported device variables (state
+    //! fields, whose contiguous multi-history buffer cannot be reproduced).
+    bool needs_mirror() const;
+
     //! lazily build (if necessary) and return the host staging mirror for a
     //! device-resident field. Must not be called for host-resident fields.
     muGrid::Field & get_host_mirror() const;

--- a/src/libmugrid/io/file_io_netcdf.hh
+++ b/src/libmugrid/io/file_io_netcdf.hh
@@ -811,7 +811,39 @@ namespace muGrid {
                       const Index_t & frame_index,
                       const Communicator & comm);
 
+    //! The field that the actual NetCDF read/write calls operate on. For
+    //! host-resident fields this is simply `get_field()`. For device-resident
+    //! (GPU) fields it is a lazily-created host-resident (AoS) staging mirror
+    //! with identical topology, so that the host-based NetCDF code path can be
+    //! reused unchanged. Buffer pointer, index map and strides must all be
+    //! taken from this field.
+    const muGrid::Field & get_io_field() const;
+
+    //! lazily build (if necessary) and return the host staging mirror for a
+    //! device-resident field. Must not be called for host-resident fields.
+    muGrid::Field & get_host_mirror() const;
+
+    //! whether this variable supports host staging of a device-resident field.
+    //! State-field variables write all history sub-fields through a single
+    //! contiguous buffer, which the (single-field) staging mirror cannot
+    //! reproduce, so they override this to return false and fail loudly.
+    virtual bool supports_device_staging() const { return true; }
+
+    //! copy device field data into the host staging mirror (before writing).
+    //! No-op for host-resident fields.
+    void stage_to_host() const;
+
+    //! copy host staging mirror data back to the device field (after reading).
+    //! No-op for host-resident fields.
+    void stage_to_device() const;
+
    protected:
+    //! host staging mirror collection, owning the mirror field. Created lazily
+    //! on first I/O of a device-resident field; null for host fields.
+    mutable std::unique_ptr<muGrid::FieldCollection> host_mirror_collection{};
+    //! the host staging mirror field, owned by host_mirror_collection.
+    mutable muGrid::Field * host_mirror_field{nullptr};
+
     std::string name;  // Variable name. Must be a legal netCDF identifier.
     nc_type data_type{NC_NAT};     // One of the predefined netCDF external data
                                    // types. NAT = Not A Type.
@@ -954,6 +986,11 @@ namespace muGrid {
 
     //! get a reference to the field represented by the NetCDF variable
     const muGrid::Field & get_field() const override;
+
+    //! State fields stream all history sub-fields through one contiguous
+    //! buffer, which the single-field host staging mirror cannot reproduce;
+    //! hence device-resident state fields are not supported (fail loudly).
+    bool supports_device_staging() const override { return false; }
 
     //! return the number of fields belonging to the state field (nb_memory + 1)
     size_t get_nb_fields() const;

--- a/src/libmugrid/memory/device.cc
+++ b/src/libmugrid/memory/device.cc
@@ -35,7 +35,61 @@
 
 #include "device.hh"
 
+#include <map>
+
+#if defined(MUGRID_ENABLE_CUDA)
+#include <cuda_runtime.h>
+#elif defined(MUGRID_ENABLE_HIP)
+#include <hip/hip_runtime.h>
+#endif
+
 namespace muGrid {
+
+#if defined(MUGRID_ENABLE_CUDA) || defined(MUGRID_ENABLE_HIP)
+namespace {
+    //! Query (once per device id, then cache) whether the GPU is an
+    //! integrated / unified-memory device whose allocations are host-coherent.
+    bool gpu_is_integrated(int device_id) {
+        static std::map<int, bool> cache{};
+        auto it{cache.find(device_id)};
+        if (it != cache.end()) {
+            return it->second;
+        }
+        bool integrated{false};
+#if defined(MUGRID_ENABLE_CUDA)
+        cudaDeviceProp prop{};
+        if (cudaGetDeviceProperties(&prop, device_id) == cudaSuccess) {
+            integrated = (prop.integrated != 0);
+        }
+#else   // MUGRID_ENABLE_HIP
+        hipDeviceProp_t prop{};
+        if (hipGetDeviceProperties(&prop, device_id) == hipSuccess) {
+            integrated = (prop.integrated != 0);
+        }
+#endif
+        cache[device_id] = integrated;
+        return integrated;
+    }
+}  // namespace
+#endif  // MUGRID_ENABLE_CUDA || MUGRID_ENABLE_HIP
+
+bool Device::is_host_accessible() const {
+    switch (this->device_type) {
+        case DeviceType::CPU:
+        case DeviceType::CUDAHost:  // pinned host memory
+        case DeviceType::ROCmHost:  // pinned host memory
+            return true;
+        case DeviceType::CUDA:
+        case DeviceType::ROCm:
+#if defined(MUGRID_ENABLE_CUDA) || defined(MUGRID_ENABLE_HIP)
+            return gpu_is_integrated(this->device_id);
+#else
+            return false;
+#endif
+        default:
+            return false;
+    }
+}
 
 std::string Device::get_device_string() const {
     switch (this->device_type) {

--- a/src/libmugrid/memory/device.hh
+++ b/src/libmugrid/memory/device.hh
@@ -97,6 +97,14 @@ class Device {
         return this->device_type == DeviceType::CPU;
     }
 
+    //! Check whether memory on this device can be dereferenced directly by the
+    //! host CPU. True for plain host memory and pinned host memory, and true
+    //! for device memory on a unified-memory / integrated device (e.g. an APU
+    //! such as the AMD MI300A), where the GPU allocation is host-coherent.
+    //! False for discrete GPUs. The result is queried from the runtime once
+    //! per device and cached. (Not constexpr: requires a runtime probe.)
+    bool is_host_accessible() const;
+
     //! Get the device type
     constexpr DeviceType get_type() const { return this->device_type; }
 

--- a/tests/io_test_file_io_netcdf.cc
+++ b/tests/io_test_file_io_netcdf.cc
@@ -930,6 +930,83 @@ namespace muGrid {
     }
   }
 
+  // Exercise the zero-copy direct path's layout handling on the CPU: a host
+  // SoA field is host-accessible, so the NetCDF code reads/writes it in place
+  // (no mirror), using the structure-of-arrays index map and the
+  // storage-order-aware buffer offset -- exactly the path a unified-memory
+  // (APU) device field takes. Data round-trips AoS -> file -> SoA -> file ->
+  // AoS and must be preserved.
+  BOOST_AUTO_TEST_CASE(SoADirectRoundTrip) {
+    auto & comm{MPIContext::get_context().comm};
+    const muGrid::FieldCollection::SubPtMap_t nb_sub_pts{{"quad", 2}};
+    const DynGridIndex nb_domain_grid_pts{3, 4};
+    const DynGridIndex nb_subdomain_grid_pts{3, 4};
+    const DynGridIndex subdomain_locations{0, 0};
+    const std::string quad{"quad"};
+    const Index_t nb_components{4};
+    const std::vector<std::string> field_names{"f"};
+
+    // AoS reference, filled in buffer order
+    muGrid::GlobalFieldCollection aos_fc{nb_domain_grid_pts,
+                                         nb_subdomain_grid_pts,
+                                         subdomain_locations, nb_sub_pts};
+    auto & aos_field{dynamic_cast<muGrid::TypedField<Real> &>(
+        aos_fc.register_real_field(field_names[0], nb_components, quad))};
+    auto aos_vec{aos_field.eigen_vec()};
+    for (Index_t i{0}; i < aos_vec.size(); ++i) {
+      aos_vec(i) = static_cast<Real>(i) + 0.5;
+    }
+    const std::string file_aos{"test_soa_direct_a.nc"};
+    {
+      muGrid::FileIONetCDF w(file_aos, muGrid::FileIOBase::OpenMode::Overwrite,
+                             comm);
+      w.register_field_collection(aos_fc, field_names);
+      w.append_frame().write(field_names);
+    }
+
+    // host SoA field: host-accessible, so written/read directly (no mirror)
+    muGrid::GlobalFieldCollection soa_fc{
+        nb_domain_grid_pts,    nb_subdomain_grid_pts, subdomain_locations,
+        nb_sub_pts,            muGrid::StorageOrder::StructureOfArrays};
+    auto & soa_field{dynamic_cast<muGrid::TypedField<Real> &>(
+        soa_fc.register_real_field(field_names[0], nb_components, quad))};
+    BOOST_CHECK(soa_field.is_host_accessible());
+    BOOST_CHECK(!soa_field.is_on_device());
+    // read the AoS file into the SoA field (SoA index map on read) ...
+    {
+      muGrid::FileIONetCDF r(file_aos, muGrid::FileIOBase::OpenMode::Read,
+                             comm);
+      r.register_field_collection(soa_fc, field_names);
+      r.read(0, field_names);
+    }
+    // ... and write it back out (SoA index map on write)
+    const std::string file_soa{"test_soa_direct_b.nc"};
+    {
+      muGrid::FileIONetCDF w(file_soa, muGrid::FileIOBase::OpenMode::Overwrite,
+                             comm);
+      w.register_field_collection(soa_fc, field_names);
+      w.append_frame().write(field_names);
+    }
+
+    // read the SoA-written file back into a standard AoS field; must match the
+    // original reference exactly
+    muGrid::GlobalFieldCollection chk_fc{nb_domain_grid_pts,
+                                         nb_subdomain_grid_pts,
+                                         subdomain_locations, nb_sub_pts};
+    auto & chk_field{dynamic_cast<muGrid::TypedField<Real> &>(
+        chk_fc.register_real_field(field_names[0], nb_components, quad))};
+    {
+      muGrid::FileIONetCDF r(file_soa, muGrid::FileIOBase::OpenMode::Read,
+                             comm);
+      r.register_field_collection(chk_fc, field_names);
+      r.read(0, field_names);
+    }
+    auto chk_vec{chk_field.eigen_vec()};
+    for (Index_t i{0}; i < aos_vec.size(); ++i) {
+      BOOST_CHECK_EQUAL(chk_vec(i), aos_vec(i));
+    }
+  }
+
 #if defined(MUGRID_ENABLE_CUDA) || defined(MUGRID_ENABLE_HIP)
   // Round-trip a device-resident field through NetCDF. On write the device
   // data is staged through a temporary host (AoS) mirror; on read it is staged

--- a/tests/io_test_file_io_netcdf.cc
+++ b/tests/io_test_file_io_netcdf.cc
@@ -46,6 +46,7 @@
 #include "field/field_map_static.hh"
 #include "collection/field_collection.hh"
 #include "field/state_field.hh"
+#include "memory/device.hh"
 
 #include "mpi_context.hh"
 
@@ -850,6 +851,209 @@ namespace muGrid {
     muGrid::NetCDFAtt att_d("d", d);
     BOOST_CHECK_EQUAL(att_d.get_data_type(), muGrid::MU_NC_REAL);
   }
+
+  // An AoS field with row-major pixel strides (the layout of the host staging
+  // mirror used for SoA device fields) must write a *canonical* NetCDF file,
+  // i.e. one that a standard col-major AoS field reads back correctly. Both
+  // fields are filled by coordinate so the comparison is purely about the
+  // on-disk layout, not the in-memory layout.
+  BOOST_AUTO_TEST_CASE(RowMajorPixelCanonical) {
+    auto & comm{MPIContext::get_context().comm};
+    const muGrid::FieldCollection::SubPtMap_t nb_sub_pts{{"quad", 2}};
+    const DynGridIndex nb_domain_grid_pts{3, 4};
+    const DynGridIndex nb_subdomain_grid_pts{3, 4};
+    const DynGridIndex subdomain_locations{0, 0};
+    const std::string quad{"quad"};
+    const Index_t nb_components{4};
+    const Index_t nb_dof{nb_components * 2};  // 2 sub-points
+    const std::vector<std::string> field_names{"f"};
+
+    auto value{[](Index_t ix, Index_t iy, Index_t d) {
+      return static_cast<Real>(ix * 1000 + iy * 100 + d);
+    }};
+
+    // standard col-major AoS field, filled by coordinate
+    muGrid::GlobalFieldCollection col_fc{nb_domain_grid_pts,
+                                         nb_subdomain_grid_pts,
+                                         subdomain_locations, nb_sub_pts};
+    auto & col_field{dynamic_cast<muGrid::TypedField<Real> &>(
+        col_fc.register_real_field(field_names[0], nb_components, quad))};
+    auto col_vec{col_field.eigen_vec()};
+    for (Index_t iy{0}; iy < 4; ++iy) {
+      for (Index_t ix{0}; ix < 3; ++ix) {
+        Index_t p{col_fc.get_index(DynGridIndex{ix, iy})};
+        for (Index_t d{0}; d < nb_dof; ++d) {
+          col_vec(p * nb_dof + d) = value(ix, iy, d);
+        }
+      }
+    }
+
+    // AoS field but with row-major pixel strides (as the SoA-device mirror
+    // would have), filled identically by coordinate
+    muGrid::GlobalFieldCollection row_fc{
+        nb_domain_grid_pts,    nb_subdomain_grid_pts,
+        subdomain_locations,   muGrid::StorageOrder::StructureOfArrays,
+        nb_sub_pts,            muGrid::StorageOrder::ArrayOfStructures};
+    auto & row_field{dynamic_cast<muGrid::TypedField<Real> &>(
+        row_fc.register_real_field(field_names[0], nb_components, quad))};
+    auto row_vec{row_field.eigen_vec()};
+    for (Index_t iy{0}; iy < 4; ++iy) {
+      for (Index_t ix{0}; ix < 3; ++ix) {
+        Index_t p{row_fc.get_index(DynGridIndex{ix, iy})};
+        for (Index_t d{0}; d < nb_dof; ++d) {
+          row_vec(p * nb_dof + d) = value(ix, iy, d);
+        }
+      }
+    }
+
+    const std::string file_name{"test_rowmajor_io.nc"};
+    {
+      muGrid::FileIONetCDF w(file_name,
+                             muGrid::FileIOBase::OpenMode::Overwrite, comm);
+      w.register_field_collection(row_fc, field_names);
+      w.append_frame().write(field_names);
+    }
+    muGrid::GlobalFieldCollection chk_fc{nb_domain_grid_pts,
+                                         nb_subdomain_grid_pts,
+                                         subdomain_locations, nb_sub_pts};
+    auto & chk_field{dynamic_cast<muGrid::TypedField<Real> &>(
+        chk_fc.register_real_field(field_names[0], nb_components, quad))};
+    {
+      muGrid::FileIONetCDF r(file_name, muGrid::FileIOBase::OpenMode::Read,
+                             comm);
+      r.register_field_collection(chk_fc, field_names);
+      r.read(0, field_names);
+    }
+    auto chk_vec{chk_field.eigen_vec()};
+    for (Index_t i{0}; i < col_vec.size(); ++i) {
+      BOOST_CHECK_EQUAL(chk_vec(i), col_vec(i));
+    }
+  }
+
+#if defined(MUGRID_ENABLE_CUDA) || defined(MUGRID_ENABLE_HIP)
+  // Round-trip a device-resident field through NetCDF. On write the device
+  // data is staged through a temporary host (AoS) mirror; on read it is staged
+  // back to the device. A multi-component field with sub-points and a SoA
+  // device collection is used so a wrong AoS<->SoA component permutation or a
+  // wrong pixel ordering during staging would be detected. Data is filled and
+  // checked by coordinate so the comparison is independent of memory layout.
+  BOOST_AUTO_TEST_CASE(DeviceFieldRoundTrip) {
+    auto & comm{MPIContext::get_context().comm};
+    const muGrid::FieldCollection::SubPtMap_t nb_sub_pts{{"quad", 2}};
+    const DynGridIndex nb_domain_grid_pts{3, 4};
+    const DynGridIndex nb_subdomain_grid_pts{3, 4};
+    const DynGridIndex subdomain_locations{0, 0};
+    const std::string quad{"quad"};
+    const Index_t nb_components{4};       // T2 tensor in 2d
+    const Index_t nb_dof{nb_components * 2};  // 2 sub-points
+    const std::vector<std::string> field_names{"device_field"};
+
+    auto value{[](Index_t ix, Index_t iy, Index_t d) {
+      return static_cast<Real>(ix * 1000 + iy * 100 + d) + 0.5;
+    }};
+
+#if defined(MUGRID_ENABLE_CUDA)
+    auto device{muGrid::Device::cuda()};
+#else
+    auto device{muGrid::Device::rocm()};
+#endif
+
+    // Build a device collection with structure-of-arrays storage (the typical
+    // GPU layout) and populate it by coordinate. The data is staged in via a
+    // host source whose pixel ordering matches the device's (row-major), so
+    // deep_copy only converts the within-pixel component order.
+    muGrid::GlobalFieldCollection device_fc{
+        nb_domain_grid_pts,    nb_subdomain_grid_pts,
+        subdomain_locations,   nb_sub_pts,
+        muGrid::StorageOrder::StructureOfArrays,
+        DynGridIndex{},        DynGridIndex{},        device};
+    auto & device_field{device_fc.register_real_field(field_names[0],
+                                                      nb_components, quad)};
+    {
+      muGrid::GlobalFieldCollection src_fc{
+          nb_domain_grid_pts,    nb_subdomain_grid_pts,
+          subdomain_locations,   muGrid::StorageOrder::StructureOfArrays,
+          nb_sub_pts,            muGrid::StorageOrder::ArrayOfStructures};
+      auto & src_field{dynamic_cast<muGrid::TypedField<Real> &>(
+          src_fc.register_real_field(field_names[0], nb_components, quad))};
+      auto src_vec{src_field.eigen_vec()};
+      for (Index_t iy{0}; iy < 4; ++iy) {
+        for (Index_t ix{0}; ix < 3; ++ix) {
+          Index_t p{src_fc.get_index(DynGridIndex{ix, iy})};
+          for (Index_t d{0}; d < nb_dof; ++d) {
+            src_vec(p * nb_dof + d) = value(ix, iy, d);
+          }
+        }
+      }
+      device_field.deep_copy_from(src_field);
+    }
+
+    // write the device field to a NetCDF file
+    const std::string file_name{"test_device_io.nc"};
+    {
+      muGrid::FileIONetCDF file_io_w(
+          file_name, muGrid::FileIOBase::OpenMode::Overwrite, comm);
+      file_io_w.register_field_collection(device_fc, field_names);
+      file_io_w.append_frame().write(field_names);
+    }
+
+    // read it into a standard (col-major AoS) host field; values must match
+    // the reference by coordinate
+    muGrid::GlobalFieldCollection check_fc{nb_domain_grid_pts,
+                                           nb_subdomain_grid_pts,
+                                           subdomain_locations, nb_sub_pts};
+    auto & check_field{dynamic_cast<muGrid::TypedField<Real> &>(
+        check_fc.register_real_field(field_names[0], nb_components, quad))};
+    {
+      muGrid::FileIONetCDF file_io_r(
+          file_name, muGrid::FileIOBase::OpenMode::Read, comm);
+      file_io_r.register_field_collection(check_fc, field_names);
+      file_io_r.read(0, field_names);
+    }
+    auto check_vec{check_field.eigen_vec()};
+    for (Index_t iy{0}; iy < 4; ++iy) {
+      for (Index_t ix{0}; ix < 3; ++ix) {
+        Index_t p{check_fc.get_index(DynGridIndex{ix, iy})};
+        for (Index_t d{0}; d < nb_dof; ++d) {
+          BOOST_CHECK_EQUAL(check_vec(p * nb_dof + d), value(ix, iy, d));
+        }
+      }
+    }
+
+    // read it back into a device field, copy to host; must match as well
+    muGrid::GlobalFieldCollection device_fc_r{
+        nb_domain_grid_pts,    nb_subdomain_grid_pts,
+        subdomain_locations,   nb_sub_pts,
+        muGrid::StorageOrder::StructureOfArrays,
+        DynGridIndex{},        DynGridIndex{},        device};
+    auto & device_field_r{device_fc_r.register_real_field(field_names[0],
+                                                          nb_components, quad)};
+    {
+      muGrid::FileIONetCDF file_io_r2(
+          file_name, muGrid::FileIOBase::OpenMode::Read, comm);
+      file_io_r2.register_field_collection(device_fc_r, field_names);
+      file_io_r2.read(0, field_names);
+    }
+    // copy the device result back to a host field with matching (row-major)
+    // pixel order so the comparison is by coordinate
+    muGrid::GlobalFieldCollection back_fc{
+        nb_domain_grid_pts,    nb_subdomain_grid_pts,
+        subdomain_locations,   muGrid::StorageOrder::StructureOfArrays,
+        nb_sub_pts,            muGrid::StorageOrder::ArrayOfStructures};
+    auto & back_field{dynamic_cast<muGrid::TypedField<Real> &>(
+        back_fc.register_real_field(field_names[0], nb_components, quad))};
+    back_field.deep_copy_from(device_field_r);
+    auto back_vec{back_field.eigen_vec()};
+    for (Index_t iy{0}; iy < 4; ++iy) {
+      for (Index_t ix{0}; ix < 3; ++ix) {
+        Index_t p{back_fc.get_index(DynGridIndex{ix, iy})};
+        for (Index_t d{0}; d < nb_dof; ++d) {
+          BOOST_CHECK_EQUAL(back_vec(p * nb_dof + d), value(ix, iy, d));
+        }
+      }
+    }
+  }
+#endif  // MUGRID_ENABLE_CUDA || MUGRID_ENABLE_HIP
 
   BOOST_AUTO_TEST_SUITE_END();
 }  // namespace muGrid


### PR DESCRIPTION
This PR add NetCDF I/O directly from a device/GPU

* On APUs (unified memory), buffers are directly passed to NetCDF
* On discrete GPUs, a mirror field is created and data is copied to the host before writing