### PR TITLE
BUG: Fix np=8 CI deadlock in BlockFourierPreconditioner Hermitian detection

### DIFF
--- a/language_bindings/python/muGrid/Preconditioners.py
+++ b/language_bindings/python/muGrid/Preconditioners.py
@@ -405,6 +405,15 @@ class BlockFourierPreconditioner(Preconditioner):
             if blocks.size
             else 0.0
         )
+        # The detection must be COLLECTIVE: a rank whose Fourier subdomain is
+        # empty (more ranks than modes along the split direction) sees an
+        # empty slab and would conclude "Hermitian" while data-carrying ranks
+        # conclude the opposite, leaving per-rank state divergent -- and any
+        # rank-dependent branching downstream deadlocks the MPI run.
+        comm = getattr(engine, "communicator", None)
+        if comm is not None:
+            herm_scale = float(comm.max(herm_scale))
+            herm_asym = float(comm.max(herm_asym))
         self._hermitian = herm_scale == 0.0 or herm_asym <= 1e-10 * herm_scale
 
         # Store the symbol at the solve precision (real diagonals, complex

--- a/language_bindings/python/muGrid/Wrappers.py
+++ b/language_bindings/python/muGrid/Wrappers.py
@@ -960,6 +960,17 @@ class FFTEngine:
                 decomposition,
             )
 
+        # Keep the (wrapped) communicator: consumers such as the
+        # preconditioners need it for collective decisions that must be
+        # consistent across ranks.
+        self._communicator = comm
+
+    @property
+    def communicator(self):
+        """The communicator this engine was constructed with (wrapped,
+        providing sum/max reductions)."""
+        return self._communicator
+
     def fft(self, input_field: Field, output_field: Field) -> None:
         """
         Forward FFT: real space -> Fourier space.


### PR DESCRIPTION
## Problem

The **Tests** and **Coverage** workflows have been red on `main` since PR #180, both failing on the same step: `mpi_mugrid_python_binding_tests-np_8` hits the 900 s ctest timeout.

## Root cause

`BlockFourierPreconditioner` decided whether its symbol is Hermitian from each rank's **local** Fourier slab. With more ranks than modes along the split direction (the np=8 job on an 8×8 grid), some ranks hold an empty Fourier subdomain and conclude "Hermitian", while data-carrying ranks conclude the opposite. In `test_block_fourier_non_hermitian_keeps_dense` the empty ranks then fail `assert prec._hermitian is False` and unwind through pytest, while the surviving ranks proceed into the **collective** `engine.fft()` and block forever — the 900 s timeout.

## Fix

- Make the detection collective: reduce `herm_scale`/`herm_asym` with `comm.max()` so every rank reaches the same verdict.
- Add an `FFTEngine.communicator` property so the preconditioner can obtain the communicator for the reduction.

## Verification

Locally, replicating the CI job:
- Full suite at **np=8** now completes in ~32 s (486 passed, was timing out at 900 s).
- Preconditioner suite passes serial and at np=2/4/8 (21 tests each).
- Serial full suite: 465 passed, 63 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)