### PR TITLE
FileIONetCDF.sync(): flush buffered frames to disk

### DIFF
--- a/language_bindings/python/bind_py_file_io.cc
+++ b/language_bindings/python/bind_py_file_io.cc
@@ -240,6 +240,12 @@ void add_file_io_netcdf(py::module & mod) {
                     Communicator>(),
            "file_name"_a, "open_mode"_a = FileIOBase::OpenMode::Read,
            "communicator"_a = Communicator())
+      .def("sync", &FileIONetCDF::sync,
+           "Flush buffered data to disk so a concurrent reader sees the "
+           "frames written so far. Call after append_frame() to checkpoint "
+           "incrementally; the PnetCDF backend already commits collective "
+           "writes, the classic/NetCDF-4 backend may otherwise buffer until "
+           "close().")
       .def("close", &FileIONetCDF::close)
       .def("register_field_collection",
            &FileIONetCDF::register_field_collection, "field_collection"_a,

--- a/src/libmugrid/io/file_io_netcdf.cc
+++ b/src/libmugrid/io/file_io_netcdf.cc
@@ -387,6 +387,27 @@ namespace muGrid {
   }
 
   /* ---------------------------------------------------------------------- */
+  void FileIONetCDF::sync() {
+    if (this->netcdf_id == -1) {
+      throw FileIOError("Cannot sync a closed file.");
+    }
+    // nc_sync/ncmpi_sync require the file to be in data mode; leave define
+    // mode first (a frame write already leaves it in data mode, but a sync
+    // right after registration/attribute writes might not).
+    if (this->netcdf_mode == NetCDFMode::DefineMode) {
+      int status_enddef{ncmu_enddef(this->netcdf_id)};
+      if (status_enddef != NC_NOERR && status_enddef != NC_ENOTINDEFINE) {
+        throw FileIOError(ncmu_strerror(status_enddef));
+      }
+      this->netcdf_mode = NetCDFMode::DataMode;
+    }
+    int err{ncmu_sync(this->netcdf_id)};
+    if (err != NC_NOERR) {
+      throw FileIOError(ncmu_strerror(err));
+    }
+  }
+
+  /* ---------------------------------------------------------------------- */
   void FileIONetCDF::close() {
     // write possibly not written global attributes if 'write()' was not called
     // even once

--- a/src/libmugrid/io/file_io_netcdf.hh
+++ b/src/libmugrid/io/file_io_netcdf.hh
@@ -58,6 +58,7 @@ const auto ncmu_enddef = ncmpi_enddef;
 const auto ncmu_redef = ncmpi_redef;
 const auto ncmu_begin_indep_data = ncmpi_begin_indep_data;
 const auto ncmu_end_indep_data = ncmpi_end_indep_data;
+const auto ncmu_sync = ncmpi_sync;
 const auto ncmu_close = ncmpi_close;
 const auto ncmu_strerror = ncmpi_strerrno;
 const auto ncmu_def_dim = ncmpi_def_dim;
@@ -88,6 +89,7 @@ const auto ncmu_create = nc_create;
 const auto ncmu_open = nc_open;
 const auto ncmu_enddef = nc_enddef;
 const auto ncmu_redef = nc_redef;
+const auto ncmu_sync = nc_sync;
 const auto ncmu_close = nc_close;
 const auto ncmu_strerror = nc_strerror;
 const auto ncmu_def_dim = nc_def_dim;
@@ -1563,6 +1565,18 @@ namespace muGrid {
      */
     void * get_frame_variable_buffer(const std::string & name,
                                      IOSize_t & size_in_bytes);
+
+    /**
+     * @brief Flushes buffered data to disk.
+     *
+     * Forces all data written so far to be committed to the file on disk
+     * (``nc_sync`` / ``ncmpi_sync``), so a reader opening the file while the
+     * simulation is still running sees the frames written up to now. Without
+     * it the classic/NetCDF-4 backend may buffer frames until :func:`close`;
+     * the PnetCDF backend already commits collective writes. Call it after
+     * :func:`append_frame` to checkpoint incrementally.
+     */
+    void sync();
 
     /**
      * @brief Closes the file.

--- a/tests/python_file_io_tests.py
+++ b/tests/python_file_io_tests.py
@@ -171,6 +171,46 @@ class FileIOTest(unittest.TestCase):
         self.assertTrue((a_glob == 1234).all())
         self.assertTrue((a_loc == 5678).all())
 
+    def test_FileIONetCDF_sync(self):
+        """sync() flushes appended frames to disk so a reader opening the file
+        while it is still being written sees the frames written so far
+        (without it the classic/NetCDF-4 backend may buffer until close())."""
+        fname = "python_binding_io_sync-tests.nc"
+        if self.comm.rank == 0 and os.path.exists(fname):
+            os.remove(fname)
+        self.comm.barrier()
+
+        fc = muGrid.GlobalFieldCollection(
+            self.nb_domain_grid_pts,
+            nb_subdomain_grid_pts=self.nb_subdomain_grid_pts,
+        )
+        field_name = "sync-test-field"
+        f = fc.register_real_field(field_name, 1, "pixel")
+        a = np.from_dlpack(f)
+
+        writer = muGrid.FileIONetCDF(fname, muGrid.OpenMode.Write, self.comm)
+        writer.register_field_collection(fc)
+
+        for k in range(3):
+            a[:] = float(k + 1)
+            writer.append_frame().write([field_name])
+            writer.sync()  # must not raise, and must commit the frame
+            self.comm.barrier()
+            # Serial: verify a concurrent read-only handle sees the frames
+            # already written (the actual flush guarantee). Skipped under MPI
+            # to avoid parallel-open file locking on the still-open writer.
+            if self.comm.size == 1:
+                reader = muGrid.FileIONetCDF(
+                    fname, muGrid.OpenMode.Read, self.comm
+                )
+                reader.register_field_collection(fc)
+                self.assertEqual(len(reader), k + 1)
+                reader.close()
+
+        writer.close()
+        if self.comm.rank == 0 and os.path.exists(fname):
+            os.remove(fname)
+
     def test_FileIONetCDF_StateFields(self):
         if self.comm.rank == 0:
             if os.path.exists(self.file_sf_name):


### PR DESCRIPTION
Adds `FileIONetCDF.sync()` — flush data written so far to disk so a reader opening the file *while a simulation is still running* sees the frames written up to now.

## Motivation

The classic / NetCDF-4 backend buffers appended frames until `close()`, so incremental checkpoints of a long run aren't visible on disk mid-simulation. The PnetCDF backend already commits collective writes. This exposes an explicit flush so callers can `append_frame().write(...)` then `sync()` and get a durable, readable checkpoint each frame regardless of backend.

## Implementation

- New `ncmu_sync` alias (`ncmpi_sync` under MPI, `nc_sync` serial) in the unified wrapper list.
- `FileIONetCDF::sync()`: leaves define mode if needed (nc_sync requires data mode), then `ncmu_sync(netcdf_id)` with error check. Bound to Python next to `close()`.

## Verification

- Compiles clean in the MPI/PnetCDF build (lib + binding).
- Functional check: a concurrent read-only handle sees each frame *immediately after* `sync()`, before the writer closes (1→2→3 frames).
- `test_FileIONetCDF_sync`: serial does the concurrent-reader frame-count assertion; MPI just asserts the call is error-free (skips the parallel-open check to avoid file-locking flakiness on the still-open writer).
- The serial `nc_sync` branch has the identical `int(int ncid)` signature as `ncmpi_sync`, so the alias is correct by construction.

Companion muTopOpt change (calls `sync()` after each dumped frame, feature-detected) follows separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)