### PR TITLE
DOC: Prepare CHANGELOG for v1.0rc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,18 @@
 Change log for µGrid
 ====================
 
-Unreleased
-----------
+v1.0rc (16Jul26)
+----------------
 
+- ENH: `FileIONetCDF.sync()` flushes buffered frames to disk for incremental
+  checkpointing of long runs
+- BUG: Autodetect GPU architecture; guard against GPU API failures
+- BUG: Guard NetCDF reads against dimension/data-type mismatch (were garbled)
+- BUG: `float32` field support in NetCDF I/O
 - BUG: Reject creating a field collection on a GPU device whose backend was not
-  compiled in (e.g. `Device.cuda()` in a CPU-only build), instead of silently
-  allocating on the host while reporting `is_device() == true`
-- BUG: `version_string()` now reports the GPU backend as `ON`/`OFF` based on the
-  build (consistent with the MPI/NetCDF sections); a passed device appends its
-  id (e.g. `CUDA: ON, device cuda:2`)
+  compiled in (e.g. `Device.cuda()` in a CPU-only build)
+- BUG: `version_string()` reports the GPU backend as `ON`/`OFF` from the build;
+  a passed device appends its id (e.g. `CUDA: ON, device cuda:2`)
 
 v0.112.0 (07Jul26)
 ------------------


### PR DESCRIPTION
## Summary

Prepares the changelog for the **v1.0rc** release candidate.

- Renamed the `Unreleased` section to `v1.0rc (16Jul26)` (matching the repo's `vX.Y (DDMonYY)` date convention).
- Added short entries for commits made since the last changelog update (`f429b95`):
  - ENH: `FileIONetCDF.sync()` flushes buffered frames to disk for incremental checkpointing (`1176bc4`)
  - BUG: Autodetect GPU architecture; guard against GPU API failures (`9fdb90d`)
  - BUG: Guard NetCDF reads against dimension/data-type mismatch (`bc4b569`)
  - BUG: `float32` field support in NetCDF I/O (`c609f40`)
- Trimmed the two pre-existing GPU-related entries for brevity.

Docs-only change; no code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016s8o6EAoK3oTrdCt56m8eq)_